### PR TITLE
Feature/jzettleNewFMObject

### DIFF
--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -13,32 +13,29 @@ namespace caf
   SRFlashMatch::SRFlashMatch():
     present(false),
     time(std::numeric_limits<float>::signaling_NaN()),
-    charge_q(std::numeric_limits<float>::signaling_NaN()),
-    light_pe(std::numeric_limits<float>::signaling_NaN()),
-    score(std::numeric_limits<float>::signaling_NaN()),
-    scr_y(std::numeric_limits<float>::signaling_NaN()),
-    scr_z(std::numeric_limits<float>::signaling_NaN()),
-    scr_rr(std::numeric_limits<float>::signaling_NaN()),
-    scr_ratio(std::numeric_limits<float>::signaling_NaN())
-    // what about chargeXYZ and lightXYZ?
-  {  }
-
+    charge(SRFlashMatch::Charge(
+             std::numeric_limits<float>::signaling_NaN(),
+             SRVector3D())),
+    light(SRFlashMatch::Flash(
+            std::numeric_limits<float>::signaling_NaN(),
+            SRVector3D())),
+    score(SRFlashMatch::Score(
+            std::numeric_limits<float>::signaling_NaN(),
+            std::numeric_limits<float>::signaling_NaN(),
+            std::numeric_limits<float>::signaling_NaN(),
+            std::numeric_limits<float>::signaling_NaN(),
+            std::numeric_limits<float>::signaling_NaN()))
+  {}
 
   SRFlashMatch::~SRFlashMatch(){  }
 
-
   void SRFlashMatch::setDefault()
   {
-    present        = false;
-    time           = -5.0;
-    charge_q       = -5.0;
-    light_pe       = -5.0;
-    score          = -5.0;
-    scr_y          = -5.0;
-    scr_z          = -5.0;
-    scr_rr         = -5.0;
-    scr_ratio      = -5.0;
-    // what about chargeXYZ and lightXYZ?
+    present = false;
+    time    = -5.0;
+    charge  = SRFlashMatch::Charge(-5.0, SRVector3D(-10.,-10.,-10.));
+    light   = SRFlashMatch::Flash(-5.0, SRVector3D(-10.,-10.,-10.));
+    score   = SRFlashMatch::Score(-5.0,-5.0,-5.0,-5.0,-5.0);
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -11,13 +11,15 @@
 namespace caf
 {
   SRFlashMatch::SRFlashMatch():
+    present(false),
+    time(std::numeric_limits<float>::signaling_NaN()),
+    pe(std::numeric_limits<float>::signaling_NaN()),
     score(std::numeric_limits<float>::signaling_NaN()),
     scr_y(std::numeric_limits<float>::signaling_NaN()),
     scr_z(std::numeric_limits<float>::signaling_NaN()),
     scr_rr(std::numeric_limits<float>::signaling_NaN()),
-    scr_ratio(std::numeric_limits<float>::signaling_NaN()),
-    time(std::numeric_limits<float>::signaling_NaN()),
-    pe(std::numeric_limits<float>::signaling_NaN())
+    scr_ratio(std::numeric_limits<float>::signaling_NaN())
+    // what about chargeXYZ and lightXYZ?
   {  }
 
 
@@ -27,13 +29,14 @@ namespace caf
   void SRFlashMatch::setDefault()
   {
     present        = false;
+    time           = -5.0;
+    pe             = -5.0;
     score          = -5.0;
     scr_y          = -5.0;
     scr_z          = -5.0;
     scr_rr         = -5.0;
     scr_ratio      = -5.0;
-    time           = -5.0;
-    pe             = -5.0;
+    // what about chargeXYZ and lightXYZ?
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -13,7 +13,8 @@ namespace caf
   SRFlashMatch::SRFlashMatch():
     present(false),
     time(std::numeric_limits<float>::signaling_NaN()),
-    pe(std::numeric_limits<float>::signaling_NaN()),
+    charge_q(std::numeric_limits<float>::signaling_NaN()),
+    light_pe(std::numeric_limits<float>::signaling_NaN()),
     score(std::numeric_limits<float>::signaling_NaN()),
     scr_y(std::numeric_limits<float>::signaling_NaN()),
     scr_z(std::numeric_limits<float>::signaling_NaN()),
@@ -30,7 +31,8 @@ namespace caf
   {
     present        = false;
     time           = -5.0;
-    pe             = -5.0;
+    charge_q       = -5.0;
+    light_pe       = -5.0;
     score          = -5.0;
     scr_y          = -5.0;
     scr_z          = -5.0;

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -13,29 +13,30 @@ namespace caf
   SRFlashMatch::SRFlashMatch():
     present(false),
     time(std::numeric_limits<float>::signaling_NaN()),
-    charge(SRFlashMatch::Charge(
-             std::numeric_limits<float>::signaling_NaN(),
-             SRVector3D())),
-    light(SRFlashMatch::Flash(
-            std::numeric_limits<float>::signaling_NaN(),
-            SRVector3D())),
-    score(SRFlashMatch::Score(
-            std::numeric_limits<float>::signaling_NaN(),
-            std::numeric_limits<float>::signaling_NaN(),
-            std::numeric_limits<float>::signaling_NaN(),
-            std::numeric_limits<float>::signaling_NaN(),
-            std::numeric_limits<float>::signaling_NaN()))
+    chargeQ(std::numeric_limits<float>::signaling_NaN()),
+    chargeCenter(SRVector3D()),
+    lightPE(std::numeric_limits<float>::signaling_NaN()),
+    lightCenter(SRVector3D()),
+    scoreTotal(std::numeric_limits<float>::signaling_NaN()),
+    scoreY(std::numeric_limits<float>::signaling_NaN()),
+    scoreZ(std::numeric_limits<float>::signaling_NaN()),
+    scoreRR(std::numeric_limits<float>::signaling_NaN()),
+    scoreRatio(std::numeric_limits<float>::signaling_NaN())
   {}
 
   SRFlashMatch::~SRFlashMatch(){  }
 
   void SRFlashMatch::setDefault()
   {
-    present = false;
-    time    = -5.0;
-    charge  = SRFlashMatch::Charge(-5.0, SRVector3D(-10.,-10.,-10.));
-    light   = SRFlashMatch::Flash(-5.0, SRVector3D(-10.,-10.,-10.));
-    score   = SRFlashMatch::Score(-5.0,-5.0,-5.0,-5.0,-5.0);
+    present    = false;
+    time       = -5.0;
+    chargeQ    = -5.0;
+    lightPE    = -5.0;
+    scoreTotal = -5.0;
+    scoreY     = -5.0;
+    scoreZ     = -5.0;
+    scoreRR    = -5.0;
+    scoreRatio = -5.0;
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -17,7 +17,7 @@ namespace caf
     chargeCenter(SRVector3D()),
     lightPE(std::numeric_limits<float>::signaling_NaN()),
     lightCenter(SRVector3D()),
-    scoreTotal(std::numeric_limits<float>::signaling_NaN()),
+    score(std::numeric_limits<float>::signaling_NaN()),
     scoreY(std::numeric_limits<float>::signaling_NaN()),
     scoreZ(std::numeric_limits<float>::signaling_NaN()),
     scoreRR(std::numeric_limits<float>::signaling_NaN()),
@@ -32,7 +32,7 @@ namespace caf
     time       = -5.0;
     chargeQ    = -5.0;
     lightPE    = -5.0;
-    scoreTotal = -5.0;
+    score      = -5.0;
     scoreY     = -5.0;
     scoreZ     = -5.0;
     scoreRR    = -5.0;

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -12,6 +12,10 @@ namespace caf
 {
   SRFlashMatch::SRFlashMatch():
     score(std::numeric_limits<float>::signaling_NaN()),
+    scr_y(std::numeric_limits<float>::signaling_NaN()),
+    scr_z(std::numeric_limits<float>::signaling_NaN()),
+    scr_rr(std::numeric_limits<float>::signaling_NaN()),
+    scr_ratio(std::numeric_limits<float>::signaling_NaN()),
     time(std::numeric_limits<float>::signaling_NaN()),
     pe(std::numeric_limits<float>::signaling_NaN())
   {  }
@@ -24,6 +28,10 @@ namespace caf
   {
     present        = false;
     score          = -5.0;
+    scr_y          = -5.0;
+    scr_z          = -5.0;
+    scr_rr         = -5.0;
+    scr_ratio      = -5.0;
     time           = -5.0;
     pe             = -5.0;
   }

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -24,7 +24,7 @@ namespace caf
       SRVector3D chargeCenter;   //!< Weighted center position [cm]
       float lightPE;             //!< photo-electrons on simple flash
       SRVector3D lightCenter;    //!< Weighted center position [cm]
-      float scoreTotal;          //!< total score, sum of terms
+      float score;               //!< total score, sum of terms
       float scoreY;              //!< score for y metric
       float scoreZ;              //!< score for z metric
       float scoreRR;             //!< score for rr metric

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -20,13 +20,13 @@ namespace caf
       virtual ~SRFlashMatch();
 
       bool  present;
+      float time;
+      float pe;
       float score;
       float scr_y;
       float scr_z;
       float scr_rr;
       float scr_ratio;
-      float time;
-      float pe;
       SRVector3D chargeXYZ;
       SRVector3D lightXYZ;
 

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -15,36 +15,20 @@ namespace caf
   class SRFlashMatch
     {
     public:
-
-      struct Charge {
-        float q;           //!< charge in slc
-        SRVector3D center; //!< Weighted center position [cm]
-        Charge(float q_, SRVector3D center_) : q(q_), center(center_) {}
-      };
-      struct Flash {
-        float pe;          //!< photo-electrons on simple flash
-        SRVector3D center; //!< Weighted center position [cm]
-        Flash(float pe_, SRVector3D center_) : pe(pe_), center(center_) {}
-      };
-      struct Score {
-        float total; //!< total score, sum of terms
-        float y;     //!< score for y metric
-        float z;     //!< score for z metric
-        float rr;    //!< score for rr metric
-        float ratio; //!< score for ratio metric
-        Score(float total_, float y_, float z_,
-              float rr_, float ratio_) :
-          total(total_), y(y_), z(z_), rr(rr_), ratio(ratio_) {}
-      };
-
       SRFlashMatch();
       virtual ~SRFlashMatch();
 
-      bool  present;
-      float time;
-      Charge charge;
-      Flash light;
-      Score score;
+      bool  present;             //!< whether there's a match
+      float time;                //!< time of flash
+      float chargeQ;             //!< charge in slc
+      SRVector3D chargeCenter;   //!< Weighted center position [cm]
+      float lightPE;             //!< photo-electrons on simple flash
+      SRVector3D lightCenter;    //!< Weighted center position [cm]
+      float scoreTotal;          //!< total score, sum of terms
+      float scoreY;              //!< score for y metric
+      float scoreZ;              //!< score for z metric
+      float scoreRR;             //!< score for rr metric
+      float scoreRatio;          //!< score for ratio metric
 
       void setDefault();
     };

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -6,6 +6,8 @@
 #ifndef SRFLASHMATCH_H
 #define SRFLASHMATCH_H
 
+#include "sbnanaobj/StandardRecord/SRVector3D.h"
+
 
 namespace caf
 {
@@ -19,8 +21,14 @@ namespace caf
 
       bool  present;
       float score;
+      float scr_y;
+      float scr_z;
+      float scr_rr;
+      float scr_ratio;
       float time;
       float pe;
+      SRVector3D chargeXYZ;
+      SRVector3D lightXYZ;
 
       void setDefault();
 

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -16,24 +16,37 @@ namespace caf
     {
     public:
 
+      struct Charge {
+        float q;           //!< charge in slc
+        SRVector3D center; //!< Weighted center position [cm]
+        Charge(float q_, SRVector3D center_) : q(q_), center(center_) {}
+      };
+      struct Flash {
+        float pe;          //!< photo-electrons on simple flash
+        SRVector3D center; //!< Weighted center position [cm]
+        Flash(float pe_, SRVector3D center_) : pe(pe_), center(center_) {}
+      };
+      struct Score {
+        float total; //!< total score, sum of terms
+        float y;     //!< score for y metric
+        float z;     //!< score for z metric
+        float rr;    //!< score for rr metric
+        float ratio; //!< score for ratio metric
+        Score(float total_, float y_, float z_,
+              float rr_, float ratio_) :
+          total(total_), y(y_), z(z_), rr(rr_), ratio(ratio_) {}
+      };
+
       SRFlashMatch();
       virtual ~SRFlashMatch();
 
       bool  present;
       float time;
-      float charge_q;
-      float light_pe;
-      float score;
-      float scr_y;
-      float scr_z;
-      float scr_rr;
-      float scr_ratio;
-      SRVector3D chargeXYZ;
-      SRVector3D lightXYZ;
+      Charge charge;
+      Flash light;
+      Score score;
 
       void setDefault();
-
-
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -21,7 +21,8 @@ namespace caf
 
       bool  present;
       float time;
-      float pe;
+      float charge_q;
+      float light_pe;
       float score;
       float scr_y;
       float scr_z;

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -14,6 +14,10 @@ namespace caf
   FlashMatch::FlashMatch():
     present(false),
     score(std::numeric_limits<float>::signaling_NaN()),
+    scr_y(std::numeric_limits<float>::signaling_NaN()),
+    scr_z(std::numeric_limits<float>::signaling_NaN()),
+    scr_rr(std::numeric_limits<float>::signaling_NaN()),
+    scr_ratio(std::numeric_limits<float>::signaling_NaN()),
     time(std::numeric_limits<float>::signaling_NaN()),
     pe(std::numeric_limits<float>::signaling_NaN())
   {}

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -14,7 +14,8 @@ namespace caf
   FlashMatch::FlashMatch():
     present(false),
     time(std::numeric_limits<float>::signaling_NaN()),
-    pe(std::numeric_limits<float>::signaling_NaN()),
+    charge_q(std::numeric_limits<float>::signaling_NaN()),
+    light_pe(std::numeric_limits<float>::signaling_NaN()),
     score(std::numeric_limits<float>::signaling_NaN()),
     scr_y(std::numeric_limits<float>::signaling_NaN()),
     scr_z(std::numeric_limits<float>::signaling_NaN()),

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -11,19 +11,6 @@
 
 namespace caf
 {
-  FlashMatch::FlashMatch():
-    present(false),
-    time(std::numeric_limits<float>::signaling_NaN()),
-    charge_q(std::numeric_limits<float>::signaling_NaN()),
-    light_pe(std::numeric_limits<float>::signaling_NaN()),
-    score(std::numeric_limits<float>::signaling_NaN()),
-    scr_y(std::numeric_limits<float>::signaling_NaN()),
-    scr_z(std::numeric_limits<float>::signaling_NaN()),
-    scr_rr(std::numeric_limits<float>::signaling_NaN()),
-    scr_ratio(std::numeric_limits<float>::signaling_NaN())
-    // what about chargeXYZ and lightXYZ?
-  {}
-
   SRSlice::SRSlice():
     producer(UINT_MAX),
     charge(std::numeric_limits<float>::signaling_NaN()),

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -13,13 +13,14 @@ namespace caf
 {
   FlashMatch::FlashMatch():
     present(false),
+    time(std::numeric_limits<float>::signaling_NaN()),
+    pe(std::numeric_limits<float>::signaling_NaN()),
     score(std::numeric_limits<float>::signaling_NaN()),
     scr_y(std::numeric_limits<float>::signaling_NaN()),
     scr_z(std::numeric_limits<float>::signaling_NaN()),
     scr_rr(std::numeric_limits<float>::signaling_NaN()),
-    scr_ratio(std::numeric_limits<float>::signaling_NaN()),
-    time(std::numeric_limits<float>::signaling_NaN()),
-    pe(std::numeric_limits<float>::signaling_NaN())
+    scr_ratio(std::numeric_limits<float>::signaling_NaN())
+    // what about chargeXYZ and lightXYZ?
   {}
 
   SRSlice::SRSlice():

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -21,7 +21,8 @@ namespace caf
     FlashMatch();
     bool present;
     float time;
-    float pe;
+    float charge_q;
+    float light_pe;
     float score;
     float scr_y;
     float scr_z;

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -15,23 +15,6 @@
 
 namespace caf
 {
-  /// A matching of TPC slice charge to Optical flash light
-  class FlashMatch {
-  public:
-    FlashMatch();
-    bool present;
-    float time;
-    float charge_q;
-    float light_pe;
-    float score;
-    float scr_y;
-    float scr_z;
-    float scr_rr;
-    float scr_ratio;
-    SRVector3D chargeXYZ;
-    SRVector3D lightXYZ;
-  };
-
   /// An  SRSlice contains overarching information for a slice.
   class SRSlice
     {
@@ -48,10 +31,9 @@ namespace caf
       SRTrueInteraction truth; //!< Truth information on the slice
       SRTruthMatch tmatch; //!< Matching information between truth and reco objects
 
+      SRFlashMatch fmatch;   //!< Optical flash-match for this slice of TPC charge
       SRFlashMatch fmatch_a; //!< Optical flash-match for this slice of TPC charge
       SRFlashMatch fmatch_b; //!< Optical flash-match for this slice of TPC charge
-
-      FlashMatch fmatch; //!< Optical flash-match for this slice of TPC charge
 
       bool is_clear_cosmic; //!< Whether pandora marks the slice as a "clear" cosmic
       int nu_pdg; //!< PDG assigned to the PFParticle Neutrino

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -19,7 +19,7 @@ namespace caf
   class FlashMatch {
   public:
     FlashMatch();
-    bool  present;
+    bool present;
     float score;
     float scr_y;
     float scr_z;

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -19,10 +19,16 @@ namespace caf
   class FlashMatch {
   public:
     FlashMatch();
-    bool present;
+    bool  present;
     float score;
+    float scr_y;
+    float scr_z;
+    float scr_rr;
+    float scr_ratio;
     float time;
     float pe;
+    SRVector3D chargeXYZ;
+    SRVector3D lightXYZ;
   };
 
   /// An  SRSlice contains overarching information for a slice.

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -20,13 +20,13 @@ namespace caf
   public:
     FlashMatch();
     bool present;
+    float time;
+    float pe;
     float score;
     float scr_y;
     float scr_z;
     float scr_rr;
     float scr_ratio;
-    float time;
-    float pe;
     SRVector3D chargeXYZ;
     SRVector3D lightXYZ;
   };
@@ -58,7 +58,7 @@ namespace caf
       std::vector<size_t> primary; //!< ID's of primary tracks and showers in slice
       int                 self;    //!< ID of the particle representing this slice
 
-      SRSliceRecoBranch   reco; //!< TPC reco information for the slice      
+      SRSliceRecoBranch   reco; //!< TPC reco information for the slice
 
       void setDefault();
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -26,11 +26,6 @@
    <version ClassVersion="10" checksum="1310903600"/>
   </class>
 
-  <class name="caf::FlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3164803337"/>
-   <version ClassVersion="10" checksum="2399434592"/>
-  </class>
-
   <class name="caf::SRFlashMatch" ClassVersion="11">
    <version ClassVersion="11" checksum="3218596620"/>
    <version ClassVersion="10" checksum="2591294730"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -26,12 +26,12 @@
   </class>
 
   <class name="caf::FlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="37120882"/>
+   <version ClassVersion="11" checksum="3164803337"/>
    <version ClassVersion="10" checksum="2399434592"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="228981019"/>
+   <version ClassVersion="11" checksum="3461639068"/>
    <version ClassVersion="10" checksum="2591294730"/>
   </class>
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -23,21 +23,10 @@
 
   <class name="caf::SRSlice" ClassVersion="11">
    <version ClassVersion="11" checksum="3227898381"/>
-   <version ClassVersion="10" checksum="1310903600"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3218596620"/>
-   <version ClassVersion="10" checksum="2591294730"/>
-  </class>
-  <class name="caf::SRFlashMatch::Charge" ClassVersion="11">
-   <version ClassVersion="11" checksum="845751663"/>
-  </class>
-  <class name="caf::SRFlashMatch::Flash" ClassVersion="11">
-   <version ClassVersion="11" checksum="30409855"/>
-  </class>
-  <class name="caf::SRFlashMatch::Score" ClassVersion="11">
-   <version ClassVersion="11" checksum="4187888130"/>
+   <version ClassVersion="11" checksum="581180094"/>
   </class>
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="10">

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -21,7 +21,8 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="10">
+  <class name="caf::SRSlice" ClassVersion="11">
+   <version ClassVersion="11" checksum="3227898381"/>
    <version ClassVersion="10" checksum="1310903600"/>
   </class>
 
@@ -31,8 +32,17 @@
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3461639068"/>
+   <version ClassVersion="11" checksum="3218596620"/>
    <version ClassVersion="10" checksum="2591294730"/>
+  </class>
+  <class name="caf::SRFlashMatch::Charge" ClassVersion="11">
+   <version ClassVersion="11" checksum="845751663"/>
+  </class>
+  <class name="caf::SRFlashMatch::Flash" ClassVersion="11">
+   <version ClassVersion="11" checksum="30409855"/>
+  </class>
+  <class name="caf::SRFlashMatch::Score" ClassVersion="11">
+   <version ClassVersion="11" checksum="4187888130"/>
   </class>
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="10">

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -26,13 +26,13 @@
   </class>
 
   <class name="caf::FlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="2399434594"/>
-   <version ClassVersion="10" checksum="1963026454"/>
+   <version ClassVersion="11" checksum="37120882"/>
+   <version ClassVersion="10" checksum="2399434592"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="2591294731"/>
-   <version ClassVersion="10" checksum="3065846543"/>
+   <version ClassVersion="11" checksum="228981019"/>
+   <version ClassVersion="10" checksum="2591294730"/>
   </class>
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="10">

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -25,11 +25,13 @@
    <version ClassVersion="10" checksum="1310903600"/>
   </class>
 
-  <class name="caf::FlashMatch" ClassVersion="10">
+  <class name="caf::FlashMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="2399434594"/>
    <version ClassVersion="10" checksum="1963026454"/>
   </class>
 
-  <class name="caf::SRFlashMatch" ClassVersion="10">
+  <class name="caf::SRFlashMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="2591294731"/>
    <version ClassVersion="10" checksum="3065846543"/>
   </class>
 


### PR DESCRIPTION
Pull request for the addition of a new sbn::SimpleFlashMatch data product replacing the anab::T0 object that was used previously. This is largely done to improve the amount of stored information from the simple flash match object in the CAF files. Tested on SBND and ICARUS simulations and shown to fill the correct object in the CAF files.