### PR TITLE
Purity and Completeness of PFPs

### DIFF
--- a/sbnanaobj/CMakeLists.txt
+++ b/sbnanaobj/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(StandardRecord)
+add_subdirectory(Morgue)

--- a/sbnanaobj/Morgue/CMakeLists.txt
+++ b/sbnanaobj/Morgue/CMakeLists.txt
@@ -1,0 +1,17 @@
+# for classes_def.xml!!
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
+
+set( PACKAGE sbnanaobj_Morgue )
+FILE( GLOB src_files *.cxx )
+
+cet_make_library( LIBRARY_NAME sbnanaobj_Morgue
+                  SOURCE       ${src_files}
+                  LIBRARIES    ${ROOT_BASIC_LIB_LIST}
+                )
+
+build_dictionary( sbnanaobj_Morgue
+                  DICTIONARY_LIBRARIES sbnanaobj_Morgue
+                )
+
+install_headers()
+install_source()

--- a/sbnanaobj/Morgue/ParticleMatch.cxx
+++ b/sbnanaobj/Morgue/ParticleMatch.cxx
@@ -1,0 +1,20 @@
+////////////////////////////////////////////////////////////////////////
+// \file    ParticleMatch.cxx
+// \brief   A ParticleMatch contains basic matching information between
+//          a reconstructed object and a true particle
+////////////////////////////////////////////////////////////////////////
+#include "sbnanaobj/Morgue/ParticleMatch.h"
+
+#include <climits>
+#include <limits>
+
+namespace caf
+{
+
+ParticleMatch::ParticleMatch():
+  G4ID(INT_MIN),
+  energy(std::numeric_limits<float>::signaling_NaN())
+{}
+
+} // end namespace caf
+////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/Morgue/ParticleMatch.h
+++ b/sbnanaobj/Morgue/ParticleMatch.h
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////
+// \file    ParticleMatch.h
+////////////////////////////////////////////////////////////////////////
+#ifndef PARTICLEMATCH_H
+#define PARTICLEMATCH_H
+
+namespace caf
+{
+  /// Match from a reconstructed track to a true particle  */
+  class ParticleMatch {
+  public:
+    ParticleMatch(); //!< Constructor
+    int G4ID; //!< ID of the particle match, taken from G4 */
+    float energy; //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
+  };
+} // end namespace
+
+#endif // PARTICLEMATCH_H
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/Morgue/ParticleMatch.h
+++ b/sbnanaobj/Morgue/ParticleMatch.h
@@ -6,12 +6,12 @@
 
 namespace caf
 {
-  /// Match from a reconstructed track to a true particle  */
+  /* Deprecated Class */
   class ParticleMatch {
   public:
-    ParticleMatch(); //!< Constructor
-    int G4ID; //!< ID of the particle match, taken from G4 */
-    float energy; //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
+    ParticleMatch();
+    int G4ID; 
+    float energy;
   };
 } // end namespace
 

--- a/sbnanaobj/Morgue/README
+++ b/sbnanaobj/Morgue/README
@@ -1,0 +1,1 @@
+This directory exists as a storage for old StandardRecord objects which are needed in order to maintain backwards compatability but should not be further used or updated.

--- a/sbnanaobj/Morgue/classes.h
+++ b/sbnanaobj/Morgue/classes.h
@@ -1,0 +1,1 @@
+#include "sbnanaobj/Morgue/ParticleMatch.h"

--- a/sbnanaobj/Morgue/classes_def.xml
+++ b/sbnanaobj/Morgue/classes_def.xml
@@ -1,0 +1,11 @@
+<!-- Include std::vector lines only for objects that are actually stored in -->
+<!-- vectors in the StandardRecord structure. Add an entry for those to     -->
+<!-- classes.h as well. -->
+
+<!-- art::Wrappers for these products are defined in CAFMaker -->
+
+<lcgdict>
+  <class name="caf::ParticleMatch" ClassVersion="10">
+   <version ClassVersion="10" checksum="3607466832"/>
+  </class>
+</lcgdict>

--- a/sbnanaobj/StandardRecord/SRParticleMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRParticleMatch.cxx
@@ -1,0 +1,20 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRParticleMatch.cxx
+// \brief   An SRParticleMatch contains matching information between
+//          a reconstructed object and a true particle
+////////////////////////////////////////////////////////////////////////
+#include "sbnanaobj/StandardRecord/SRParticleMatch.h"
+
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+
+SRParticleMatch::SRParticleMatch():
+  G4ID(INT_MIN),
+  energy(std::numeric_limits<float>::signaling_NaN())
+{}
+
+} // end namespace caf
+////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRParticleMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRParticleMatch.cxx
@@ -13,7 +13,11 @@ namespace caf
 
 SRParticleMatch::SRParticleMatch():
   G4ID(INT_MIN),
-  energy(std::numeric_limits<float>::signaling_NaN())
+  energy(std::numeric_limits<float>::signaling_NaN()),
+  hit_completeness(std::numeric_limits<float>::signaling_NaN()),
+  hit_purity(std::numeric_limits<float>::signaling_NaN()),
+  energy_completeness(std::numeric_limits<float>::signaling_NaN()),
+  energy_purity(std::numeric_limits<float>::signaling_NaN())
 {}
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRParticleMatch.h
+++ b/sbnanaobj/StandardRecord/SRParticleMatch.h
@@ -9,9 +9,14 @@ namespace caf
   /// Match from a reconstructed track to a true particle  */
   class SRParticleMatch {
   public:
-    SRParticleMatch();   //!< Constructor
-    int G4ID;          //!< ID of the particle match, taken from G4 */
-    float energy;      //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
+    SRParticleMatch();            //!< Constructor
+    int G4ID;                     //!< ID of the particle match, taken from G4 */
+    float energy;                 //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
+
+    float hit_completeness;       //!< The fraction of the best true particle's hits contained by the reconstructed object
+    float hit_purity;             //!< The fraction of the reconstructed object's hits that originate from the best true particle
+    float energy_completeness;    //!< The fraction of the best true particle's energy contained by the reconstructed object
+    float energy_purity;          //!< The fraction of the reconstructed object's energy that originates from the best true particle
   };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRParticleMatch.h
+++ b/sbnanaobj/StandardRecord/SRParticleMatch.h
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRParticleMatch.h
+////////////////////////////////////////////////////////////////////////
+#ifndef SRPARTICLEMATCH_H
+#define SRPARTICLEMATCH_H
+
+namespace caf
+{
+  /// Match from a reconstructed track to a true particle  */
+  class SRParticleMatch {
+  public:
+    SRParticleMatch();   //!< Constructor
+    int G4ID;          //!< ID of the particle match, taken from G4 */
+    float energy;      //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
+  };
+} // end namespace
+
+#endif // SRPARTICLEMATCH_H
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRTrackTruth.cxx
+++ b/sbnanaobj/StandardRecord/SRTrackTruth.cxx
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////
-// \file    SRTrack.cxx
-// \brief   An SRTrack is a high level track object.  It knows its
-//          direction and length, but does not own its cell hits.
+// \file    SRTrackTruth.cxx
+// \brief   An SRTrackTruth contains the matching information between an
+//          SRTrack and a list of SRTrueParticles
 ////////////////////////////////////////////////////////////////////////
 #include "sbnanaobj/StandardRecord/SRTrackTruth.h"
 
@@ -14,11 +14,6 @@ namespace caf
 SRTrackTruth::SRTrackTruth():
   total_deposited_energy(std::numeric_limits<float>::signaling_NaN()),
   nmatches(0)
-{}
-
-ParticleMatch::ParticleMatch():
-  G4ID(INT_MIN),
-  energy(std::numeric_limits<float>::signaling_NaN())
 {}
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRTrackTruth.h
+++ b/sbnanaobj/StandardRecord/SRTrackTruth.h
@@ -6,17 +6,10 @@
 
 #include <vector>
 #include "SRTrueParticle.h"
+#include "SRParticleMatch.h"
 
 namespace caf
 {
-  /// Match from a reconstructed track to a true particle  */
-  class ParticleMatch {
-  public:
-    ParticleMatch(); //!< Constructor
-    int G4ID; //!< ID of the particle match, taken from G4 */
-    float energy; //!< Total energy matching between reco track and true particle across all three planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane */
-  };
-
   /// Truth matching information between a SRTrack and a list of SRTrueParticle objects
   /// matching is done using the sum of energies on each plane, so energy variables use the sum of energy
   /// seen by each plane
@@ -28,8 +21,8 @@ namespace caf
     float total_deposited_energy; //!< True total deposited energy associated with this Track across all 3 planes [GeV]. NOTE: this energy is a sum of the depoisted energy as seen individually by each plane
   
     int                       nmatches; //!< Number of matches
-    std::vector<ParticleMatch> matches; //!< List of particle matches, sorted by most energy matched */
-    ParticleMatch bestmatch; //!< Best match for track (most energy). Same as index-0 of matches. Useful for columnar analyses.
+    std::vector<SRParticleMatch> matches; //!< List of particle matches, sorted by most energy matched */
+    SRParticleMatch bestmatch; //!< Best match for track (most energy). Same as index-0 of matches. Useful for columnar analyses.
     SRTrueParticle p; //!< A copy of the true particle for the best match. Set to nonsense if there is no such match.
   };
 } // end namespace

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -62,11 +62,13 @@
    <version ClassVersion="10" checksum="1169960296"/>
   </class>
 
-  <class name="caf::SRTrackTruth" ClassVersion="10">
+  <class name="caf::SRTrackTruth" ClassVersion="11">
+   <version ClassVersion="11" checksum="3541008994"/>
    <version ClassVersion="10" checksum="2876855736"/>
   </class>
 
-  <class name="caf::ParticleMatch" ClassVersion="10">
+  <class name="caf::SRParticleMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="3083434249"/>
    <version ClassVersion="10" checksum="3607466832"/>
   </class>
 
@@ -192,7 +194,7 @@
   <class name="std::vector<caf::SRTrueInteraction>" />
   <class name="std::vector<caf::SRMultiverse>" />
   <class name="std::vector<caf::SRTrueParticle>" />
-  <class name="std::vector<caf::ParticleMatch>" />
+  <class name="std::vector<caf::SRParticleMatch>" />
 
   <class name="caf::SRCRTHit" ClassVersion="10">
    <version ClassVersion="10" checksum="3162534166"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -67,9 +67,21 @@
    <version ClassVersion="10" checksum="2876855736"/>
   </class>
 
-  <class name="caf::SRParticleMatch" ClassVersion="10">
-   <version ClassVersion="10" checksum="3613006913"/>
+  <class name="caf::SRParticleMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="3613006913"/>
+   <version ClassVersion="10" checksum="3607466832"/>
   </class>
+
+  <!-- Allows us to convert from the deprecated ParticleMatch 
+       to the newer SRParticleMatch to open old files -->
+  <ioread targetClass="caf::SRParticleMatch" sourceClass="caf::ParticleMatch" version="[-10]"
+    source="int G4ID;" target="G4ID" >
+    <![CDATA[{ G4ID = onfile.G4ID; }]]>
+  </ioread>
+  <ioread targetClass="caf::SRParticleMatch" sourceClass="caf::ParticleMatch" version="[-10]"
+    source="float energy;" target="energy" >
+    <![CDATA[{ energy = onfile.energy; }]]>
+  </ioread>
 
   <class name="caf::SRCaloPoint" ClassVersion="10">
    <version ClassVersion="10" checksum="3748600600"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -67,9 +67,8 @@
    <version ClassVersion="10" checksum="2876855736"/>
   </class>
 
-  <class name="caf::SRParticleMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3083434249"/>
-   <version ClassVersion="10" checksum="3607466832"/>
+  <class name="caf::SRParticleMatch" ClassVersion="10">
+   <version ClassVersion="10" checksum="3613006913"/>
   </class>
 
   <class name="caf::SRCaloPoint" ClassVersion="10">
@@ -195,6 +194,11 @@
   <class name="std::vector<caf::SRMultiverse>" />
   <class name="std::vector<caf::SRTrueParticle>" />
   <class name="std::vector<caf::SRParticleMatch>" />
+  <class name="std::vector<caf::SRCaloPoint>" />
+  <class name="std::vector<caf::SRMeVPrtl>" />
+  <class name="std::vector<caf::SRStub>" />
+  <class name="std::vector<caf::SRStubHit>" />
+  <class name="std::vector<caf::SRStubPlane>" />
 
   <class name="caf::SRCRTHit" ClassVersion="10">
    <version ClassVersion="10" checksum="3162534166"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -69,7 +69,6 @@
 
   <class name="caf::SRParticleMatch" ClassVersion="11">
    <version ClassVersion="11" checksum="3613006913"/>
-   <version ClassVersion="10" checksum="3607466832"/>
   </class>
 
   <!-- Allows us to convert from the deprecated ParticleMatch 


### PR DESCRIPTION
This PR adds the required data members in the truth match objects to store the hit and energy versions of completeness and purity.

It also takes the ParticleMatch object within SRTrackTruth and separates it as its own class SRParticleMatch.

This PR is associated with SBNSoftware/sbncode#182 which provides the functionality to fill these variables. 

The extra definitions in classes_def.xml were required to run the CAFMaker successfully.