### PR TITLE
Ensure initialisations

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTHit.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTHit.cxx
@@ -9,7 +9,8 @@ namespace caf
 
   SRCRTHit::SRCRTHit():
     time(std::numeric_limits<float>::signaling_NaN()),
-    pe(std::numeric_limits<float>::signaling_NaN())
+    pe(std::numeric_limits<float>::signaling_NaN()),
+    plane(INT_MIN)
   {}
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTHit.h
+++ b/sbnanaobj/StandardRecord/SRCRTHit.h
@@ -5,6 +5,7 @@
 #define SRCRTHIT_H
 
 #include "sbnanaobj/StandardRecord/SRVector3D.h"
+#include <climits>
 
 namespace caf
 {

--- a/sbnanaobj/StandardRecord/SRTrack.cxx
+++ b/sbnanaobj/StandardRecord/SRTrack.cxx
@@ -20,7 +20,8 @@ namespace caf
     npts(-1),
     len(kInvalid),
     costh(kInvalid),
-    phi(kInvalid)
+    phi(kInvalid),
+    ID(INT_MIN)
   {
   }
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRTrueParticle.cxx
+++ b/sbnanaobj/StandardRecord/SRTrueParticle.cxx
@@ -31,6 +31,7 @@ namespace caf
     G4ID(INT_MIN),
     interaction_id(INT_MIN),
     cryostat(-1),
+    parent(UINT_MAX),
     generator(kUnknownGenerator),
     start_process(g4_process_(caf::kG4UNKNOWN)), 
     end_process(g4_process_(caf::kG4UNKNOWN)),


### PR DESCRIPTION
Whilst working on a CI test for the CAF files I came across a regular difference in supposedly "identical" files. Two values would often differ the `parent` value in `SRTrueParticle`'s and the `plane` value in `SRCRTHit`'s. 

Both of these can be solved by ensuring that the value is correctly initialised, such that if they are not filled for a particular instance they don't just take on a random value.