### PR TITLE
Usable POT accounting in CAFs based on BNBRetriever module

### DIFF
--- a/sbnanaobj/StandardRecord/SRBNBInfo.cxx
+++ b/sbnanaobj/StandardRecord/SRBNBInfo.cxx
@@ -26,12 +26,11 @@ namespace caf
     M876BB_spill_time_diff(std::numeric_limits<float>::signaling_NaN()),
     MMBTBB_spill_time_diff(std::numeric_limits<float>::signaling_NaN())
   {}
-  SRBNBInfo::~SRBNBInfo() {}
 
   void SRBNBInfo::setDefault()
   {
-    spill_time_sec = 0;
-    spill_time_nsec = 0;
+    spill_time_sec = UINT_MAX;
+    spill_time_nsec = UINT_MAX;
     event = UINT_MAX;
     TOR860 = -999.0;
     TOR875 = -999.0;

--- a/sbnanaobj/StandardRecord/SRBNBInfo.cxx
+++ b/sbnanaobj/StandardRecord/SRBNBInfo.cxx
@@ -1,0 +1,54 @@
+#include "sbnanaobj/StandardRecord/SRBNBInfo.h"
+
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+  SRBNBInfo::SRBNBInfo():
+    spill_time_sec(UINT_MAX),
+    spill_time_nsec(UINT_MAX),
+    event(UINT_MAX),
+    TOR860(std::numeric_limits<float>::signaling_NaN()),
+    TOR875(std::numeric_limits<float>::signaling_NaN()),
+    LM875A(std::numeric_limits<float>::signaling_NaN()),
+    LM875B(std::numeric_limits<float>::signaling_NaN()),
+    LM875C(std::numeric_limits<float>::signaling_NaN()),
+    HP875(std::numeric_limits<float>::signaling_NaN()),
+    VP875(std::numeric_limits<float>::signaling_NaN()),
+    HPTG1(std::numeric_limits<float>::signaling_NaN()),
+    VPTG1(std::numeric_limits<float>::signaling_NaN()),
+    HPTG2(std::numeric_limits<float>::signaling_NaN()),
+    VPTG2(std::numeric_limits<float>::signaling_NaN()),
+    BTJT2(std::numeric_limits<float>::signaling_NaN()),
+    THCURR(std::numeric_limits<float>::signaling_NaN()),
+    M875BB_spill_time_diff(std::numeric_limits<float>::signaling_NaN()),
+    M876BB_spill_time_diff(std::numeric_limits<float>::signaling_NaN()),
+    MMBTBB_spill_time_diff(std::numeric_limits<float>::signaling_NaN())
+  {}
+  SRBNBInfo::~SRBNBInfo() {}
+
+  void SRBNBInfo::setDefault()
+  {
+    spill_time_sec = 0;
+    spill_time_nsec = 0;
+    event = UINT_MAX;
+    TOR860 = -999.0;
+    TOR875 = -999.0;
+    LM875A = -999.0;
+    LM875B = -999.0;
+    LM875C = -999.0;
+    HP875 = -999.0;
+    VP875 = -999.0;
+    HPTG1 = -999.0;
+    VPTG1 = -999.0;
+    HPTG2 = -999.0;
+    VPTG2 = -999.0;
+    BTJT2 = -999.0;
+    THCURR = -999.0;
+    M875BB_spill_time_diff = -999.0;
+    M876BB_spill_time_diff = -999.0;
+    MMBTBB_spill_time_diff = -999.0;
+  }
+    
+} //end namespace caf

--- a/sbnanaobj/StandardRecord/SRBNBInfo.cxx
+++ b/sbnanaobj/StandardRecord/SRBNBInfo.cxx
@@ -6,8 +6,8 @@
 namespace caf
 {
   SRBNBInfo::SRBNBInfo():
-    spill_time_sec(UINT_MAX),
-    spill_time_nsec(UINT_MAX),
+    spill_time_sec(std::numeric_limits<unsigned long int>::max()),
+    spill_time_nsec(std::numeric_limits<unsigned long int>::max()),
     event(UINT_MAX),
     TOR860(std::numeric_limits<float>::signaling_NaN()),
     TOR875(std::numeric_limits<float>::signaling_NaN()),
@@ -29,8 +29,8 @@ namespace caf
 
   void SRBNBInfo::setDefault()
   {
-    spill_time_sec = UINT_MAX;
-    spill_time_nsec = UINT_MAX;
+    spill_time_sec = std::numeric_limits<unsigned long int>::max();
+    spill_time_nsec = std::numeric_limits<unsigned long int>::max();
     event = UINT_MAX;
     TOR860 = -999.0;
     TOR875 = -999.0;

--- a/sbnanaobj/StandardRecord/SRBNBInfo.h
+++ b/sbnanaobj/StandardRecord/SRBNBInfo.h
@@ -1,0 +1,52 @@
+#ifndef SRBNBINFO_h
+#define SRBNBINFO_h
+
+#include <vector>
+
+namespace caf
+{
+  class SRBNBInfo
+  {
+  public:
+    SRBNBInfo();
+    virtual ~SRBNBInfo();
+    
+    unsigned long int spill_time_sec;
+    unsigned long int spill_time_nsec;
+    unsigned int event;
+
+    float TOR860;  
+    float TOR875; //!< Value used for POT accounting
+
+    float LM875A; //!< Loss Monitor before the RWM, unit R/s
+    float LM875B; //!< Loss Monitor after the RWM, unit R/s
+    float LM875C; //!< Loss Monitor after the RWM, unit R/s
+    float HP875; //!< Horizontal Position Monitor after Mag 875, units mm
+    float VP875; //!< Verticle Position Monitor after Mag 875, units mm
+
+    float HPTG1; //!< Horizontal Position Monitor at Target Station 1, units mm 
+    float VPTG1; //!< Horizontal Position Monitor at Target Station 1, units mm
+
+    float HPTG2; //!< Horizontal Position Monitor at Target Station 2, closest to target, units mm
+    float VPTG2; //!< Horizontal Position Monitor at Target Station 2, closest to target, units mm
+    
+    float BTJT2; //!< Temperature of air exiting target, units Deg C
+
+    float THCURR; //!< Current applied to Horn, units kiloAmperes 
+    
+    // https://cdcvs.fnal.gov/redmine/projects/ubraw/repository/revisions/master/entry/ubraw/BeamDAQ/MWRData.cpp
+    std::vector< int > M875BB; //!< Multiwire station before Mag 875...?
+    std::vector< int > M876BB; //!< Multiwire station after Mag 875...?
+    std::vector< int > MMBTBB; //!< Multiwire station at the target station, 
+    
+    float M875BB_spill_time_diff; //!< the time difference between M875BB and the matched spill
+    float M876BB_spill_time_diff; //!< the time difference between M876BB and the matched spill
+    float MMBTBB_spill_time_diff; //!< the time difference between MMBTBB and the matched spill
+
+    void setDefault();
+
+    
+  };
+} //end namespace caf
+
+#endif

--- a/sbnanaobj/StandardRecord/SRBNBInfo.h
+++ b/sbnanaobj/StandardRecord/SRBNBInfo.h
@@ -9,7 +9,6 @@ namespace caf
   {
   public:
     SRBNBInfo();
-    virtual ~SRBNBInfo();
     
     unsigned long int spill_time_sec;
     unsigned long int spill_time_nsec;

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -6,6 +6,9 @@
 #define SRHEADER_H
 
 #include "sbnanaobj/StandardRecord/SREnums.h"
+#include "sbnanaobj/StandardRecord/SRBNBInfo.h"
+
+#include <vector>
 
 namespace caf
 {
@@ -33,6 +36,7 @@ namespace caf
       int            proc; //< Process number of job that created CAF file
       int            cluster; //< Cluster number of job that created CAF file
       // bool           blind;     ///< if true, record has been corrupted for blindness
+      std::vector<caf::SRBNBInfo> bnbinfo; ///< storing beam information per subrun
 
     };
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -9,7 +9,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="11">
+  <class name="caf::SRHeader" ClassVersion="12">
+   <version ClassVersion="12" checksum="225578773"/>
    <version ClassVersion="11" checksum="2592833259"/>
    <version ClassVersion="10" checksum="2908097963"/>
   </class>
@@ -197,6 +198,10 @@
    <version ClassVersion="10" checksum="133600353"/>
   </class>
 
+  <class name="caf::SRBNBInfo" ClassVersion="10">
+   <version ClassVersion="10" checksum="2143749817"/>
+  </class>
+
   <!--<class name="caf::SRLorentzVector" /> -->
 
   <class name="std::vector<caf::SRSlice>" />
@@ -218,6 +223,7 @@
   <class name="std::vector<caf::SRStub>" />
   <class name="std::vector<caf::SRStubHit>" />
   <class name="std::vector<caf::SRStubPlane>" />
+  <class name="std::vector<caf::SRBNBInfo>" />
 
   <class name="caf::SRCRTHit" ClassVersion="10">
    <version ClassVersion="10" checksum="3162534166"/>


### PR DESCRIPTION
Add POT Accounting information for CAFs produced by BNBRetriever module. Stored in SRHeader and currently per event. More ideal would be per subrun