### PR TITLE
Add the hdr.husk flag to support the ability to reduce files without losing track of their POT

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -25,8 +25,9 @@ namespace caf
   mctype(caf::kMCUnknown),
   det(caf::kUNKNOWN),
   proc(-1),
-  cluster(-1)
+  cluster(-1),
   // blind(false),
+  husk(false)
   {  }
 
   SRHeader::~SRHeader(){  }

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -34,6 +34,10 @@ namespace caf
       int            cluster; //< Cluster number of job that created CAF file
       // bool           blind;     ///< if true, record has been corrupted for blindness
 
+      /// If true, this record has been filterd out, and only remains as a
+      /// receptacle for exposure information. It should be skipped in any
+      /// analysis, apart from for including its POT.
+      bool           husk;
     };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -9,7 +9,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="11">
+  <class name="caf::SRHeader" ClassVersion="12">
+   <version ClassVersion="12" checksum="3508873578"/>
    <version ClassVersion="11" checksum="2592833259"/>
    <version ClassVersion="10" checksum="2908097963"/>
   </class>


### PR DESCRIPTION
I struggled to come up with a succint name/metaphor for this concept. Anyone want to dive into a thesaurus and come up with something better than `husk`?