### PR TITLE
NuMI Spill Accounting in StandardRecord

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -7,6 +7,7 @@
 
 #include "sbnanaobj/StandardRecord/SREnums.h"
 #include "sbnanaobj/StandardRecord/SRBNBInfo.h"
+#include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
 
 #include <vector>
 
@@ -37,6 +38,7 @@ namespace caf
       int            cluster; //< Cluster number of job that created CAF file
       // bool           blind;     ///< if true, record has been corrupted for blindness
       std::vector<caf::SRBNBInfo> bnbinfo; ///< storing beam information per subrun
+      std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any

--- a/sbnanaobj/StandardRecord/SRNuMIInfo.cxx
+++ b/sbnanaobj/StandardRecord/SRNuMIInfo.cxx
@@ -1,0 +1,23 @@
+#include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
+
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+  SRNuMIInfo::SRNuMIInfo():
+    HRNDIR(std::numeric_limits<float>::signaling_NaN()),
+    NSLINA(std::numeric_limits<float>::signaling_NaN()),
+    NSLINB(std::numeric_limits<float>::signaling_NaN()),
+    NSLINC(std::numeric_limits<float>::signaling_NaN()),
+    NSLIND(std::numeric_limits<float>::signaling_NaN()),
+    TRTGTD(std::numeric_limits<float>::signaling_NaN()),
+    TR101D(std::numeric_limits<float>::signaling_NaN()),
+
+    spill_time_s(std::numeric_limits<unsigned long int>::max()),
+    spill_time_ns(std::numeric_limits<unsigned long int>::max()),
+    event(UINT_MAX),
+    daq_gates(UINT_MAX)
+  {}
+}
+

--- a/sbnanaobj/StandardRecord/SRNuMIInfo.cxx
+++ b/sbnanaobj/StandardRecord/SRNuMIInfo.cxx
@@ -13,6 +13,9 @@ namespace caf
     NSLIND(std::numeric_limits<float>::signaling_NaN()),
     TRTGTD(std::numeric_limits<float>::signaling_NaN()),
     TR101D(std::numeric_limits<float>::signaling_NaN()),
+    TORTGT(std::numeric_limits<float>::signaling_NaN()),
+    TOR101(std::numeric_limits<float>::signaling_NaN()),
+    time(std::numeric_limits<float>::signaling_NaN()),
 
     spill_time_s(std::numeric_limits<unsigned long int>::max()),
     spill_time_ns(std::numeric_limits<unsigned long int>::max()),

--- a/sbnanaobj/StandardRecord/SRNuMIInfo.h
+++ b/sbnanaobj/StandardRecord/SRNuMIInfo.h
@@ -1,0 +1,36 @@
+#ifndef SRNuMIINFO_h
+#define SRNuMIINFO_h
+
+#include <vector>
+
+namespace caf
+{
+  class SRNuMIInfo
+  {
+  public:
+    SRNuMIInfo();
+
+    std::vector< double > HP121;
+    std::vector< double > VP121;
+    std::vector< double > HPTGT;
+    std::vector< double > VPTGT;
+    std::vector< double > HITGT;
+    std::vector< double > VITGT;
+    std::vector< double > MTGTDS; //MULTIWIRES
+    float HRNDIR; // horn polarity (based on sign)
+    float NSLINA; // horn current /4 
+    float NSLINB; // horn current /4  
+    float NSLINC; // horn current /4 
+    float NSLIND; // horn current /4 
+    float TRTGTD;
+    float TR101D;
+
+    unsigned long int spill_time_s; //!< The IFDB Beam Spill Time, unit sec
+    unsigned long int spill_time_ns; //!< The IFDB Beam Spill Time, unit nsec
+
+    unsigned int event;
+    unsigned int daq_gates;
+
+  };
+}
+#endif

--- a/sbnanaobj/StandardRecord/SRNuMIInfo.h
+++ b/sbnanaobj/StandardRecord/SRNuMIInfo.h
@@ -24,6 +24,9 @@ namespace caf
     float NSLIND; // horn current /4 
     float TRTGTD;
     float TR101D;
+    float TORTGT;
+    float TOR101;
+    float time; //!< Time of device used to lookup spill
 
     unsigned long int spill_time_s; //!< The IFDB Beam Spill Time, unit sec
     unsigned long int spill_time_ns; //!< The IFDB Beam Spill Time, unit nsec

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -204,7 +204,7 @@
    <version ClassVersion="10" checksum="2143749817"/>
   </class>
   <class name="caf::SRNuMIInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="2793623668"/>
+   <version ClassVersion="10" checksum="3796231674"/>
   </class>
 
   <!--<class name="caf::SRLorentzVector" /> -->

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -9,7 +9,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="13">
+  <class name="caf::SRHeader" ClassVersion="14">
+   <version ClassVersion="14" checksum="381900980"/>
     <version ClassVersion="13" checksum="2553933268"/>
     <version ClassVersion="12" checksum="3508873578"/>
    <version ClassVersion="11" checksum="2592833259"/>
@@ -201,6 +202,9 @@
 
   <class name="caf::SRBNBInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="2143749817"/>
+  </class>
+  <class name="caf::SRNuMIInfo" ClassVersion="10">
+   <version ClassVersion="10" checksum="2793623668"/>
   </class>
 
   <!--<class name="caf::SRLorentzVector" /> -->


### PR DESCRIPTION
Add in object for NuMI beamline info into the StandardRecord. Intended for the release branch