### PR TITLE
CRUMBS

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -1,0 +1,30 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRCRUMBSResult.cxx
+////////////////////////////////////////////////////////////////////////
+
+#include "sbnanaobj/StandardRecord/SRCRUMBSResult.h"
+
+namespace caf {
+SRCRUMBSResult::SRCRUMBSResult()
+  : score(-5.f)
+  , tpc_CRFracHitsInLongestTrack(-5.f)
+  , tpc_CRLongestTrackDeflection(-5.f)
+  , tpc_CRLongestTrackDirY(-5.f)
+  , tpc_CRNHitsMax(-5.f)
+  , tpc_NuEigenRatioInSphere(-5.f)
+  , tpc_NuNFinalStatePfos(-5.f)
+  , tpc_NuNHitsTotal(-5.f)
+  , tpc_NuNSpacePointsInSphere(-5.f)
+  , tpc_NuVertexY(-5.f)
+  , tpc_NuWeightedDirZ(-5.f)
+  , tpc_StoppingChi2CosmicRatio(-5.f)
+  , pds_FMTotalScore(-5.f)
+  , pds_FMPE(-5.f)
+  , pds_FMTime(-5.f)
+  , crt_TrackScore(-5.f)
+  , crt_HitScore(-5.f)
+{
+}
+
+} // end namespace
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -3,28 +3,29 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "sbnanaobj/StandardRecord/SRCRUMBSResult.h"
+#include <limits>
 
 namespace caf {
 SRCRUMBSResult::SRCRUMBSResult()
-  : score(-5.f)
-  , tpc_CRFracHitsInLongestTrack(-5.f)
-  , tpc_CRLongestTrackDeflection(-5.f)
-  , tpc_CRLongestTrackDirY(-5.f)
-  , tpc_CRNHitsMax(-5.f)
-  , tpc_NuEigenRatioInSphere(-5.f)
-  , tpc_NuNFinalStatePfos(-5.f)
-  , tpc_NuNHitsTotal(-5.f)
-  , tpc_NuNSpacePointsInSphere(-5.f)
-  , tpc_NuVertexY(-5.f)
-  , tpc_NuWeightedDirZ(-5.f)
-  , tpc_StoppingChi2CosmicRatio(-5.f)
-  , pds_FMTotalScore(-5.f)
-  , pds_FMPE(-5.f)
-  , pds_FMTime(-5.f)
-  , crt_TrackScore(-5.f)
-  , crt_HitScore(-5.f)
-  , crt_TrackTime(-5.f)
-  , crt_HitTime(-5.f)
+  : score(std::numeric_limits<float>::signaling_NaN())
+  , tpc_CRFracHitsInLongestTrack(std::numeric_limits<float>::signaling_NaN())
+  , tpc_CRLongestTrackDeflection(std::numeric_limits<float>::signaling_NaN())
+  , tpc_CRLongestTrackDirY(std::numeric_limits<float>::signaling_NaN())
+  , tpc_CRNHitsMax(std::numeric_limits<int>::max())
+  , tpc_NuEigenRatioInSphere(std::numeric_limits<float>::signaling_NaN())
+  , tpc_NuNFinalStatePfos(std::numeric_limits<int>::max())
+  , tpc_NuNHitsTotal(std::numeric_limits<int>::max())
+  , tpc_NuNSpacePointsInSphere(std::numeric_limits<int>::max())
+  , tpc_NuVertexY(std::numeric_limits<float>::signaling_NaN())
+  , tpc_NuWeightedDirZ(std::numeric_limits<float>::signaling_NaN())
+  , tpc_StoppingChi2CosmicRatio(std::numeric_limits<float>::signaling_NaN())
+  , pds_FMTotalScore(std::numeric_limits<float>::signaling_NaN())
+  , pds_FMPE(std::numeric_limits<float>::signaling_NaN())
+  , pds_FMTime(std::numeric_limits<float>::signaling_NaN())
+  , crt_TrackScore(std::numeric_limits<float>::signaling_NaN())
+  , crt_HitScore(std::numeric_limits<float>::signaling_NaN())
+  , crt_TrackTime(std::numeric_limits<float>::signaling_NaN())
+  , crt_HitTime(std::numeric_limits<float>::signaling_NaN())
 {
 }
 

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -23,6 +23,8 @@ SRCRUMBSResult::SRCRUMBSResult()
   , pds_FMTime(-5.f)
   , crt_TrackScore(-5.f)
   , crt_HitScore(-5.f)
+  , crt_TrackTime(-5.f)
+  , crt_HitTime(-5.f)
 {
 }
 

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -6,28 +6,44 @@
 #include <limits>
 
 namespace caf {
-SRCRUMBSResult::SRCRUMBSResult()
-  : score(std::numeric_limits<float>::signaling_NaN())
-  , tpc_CRFracHitsInLongestTrack(std::numeric_limits<float>::signaling_NaN())
-  , tpc_CRLongestTrackDeflection(std::numeric_limits<float>::signaling_NaN())
-  , tpc_CRLongestTrackDirY(std::numeric_limits<float>::signaling_NaN())
-  , tpc_CRNHitsMax(std::numeric_limits<int>::max())
-  , tpc_NuEigenRatioInSphere(std::numeric_limits<float>::signaling_NaN())
-  , tpc_NuNFinalStatePfos(std::numeric_limits<int>::max())
-  , tpc_NuNHitsTotal(std::numeric_limits<int>::max())
-  , tpc_NuNSpacePointsInSphere(std::numeric_limits<int>::max())
-  , tpc_NuVertexY(std::numeric_limits<float>::signaling_NaN())
-  , tpc_NuWeightedDirZ(std::numeric_limits<float>::signaling_NaN())
-  , tpc_StoppingChi2CosmicRatio(std::numeric_limits<float>::signaling_NaN())
-  , pds_FMTotalScore(std::numeric_limits<float>::signaling_NaN())
-  , pds_FMPE(std::numeric_limits<float>::signaling_NaN())
-  , pds_FMTime(std::numeric_limits<float>::signaling_NaN())
-  , crt_TrackScore(std::numeric_limits<float>::signaling_NaN())
-  , crt_HitScore(std::numeric_limits<float>::signaling_NaN())
-  , crt_TrackTime(std::numeric_limits<float>::signaling_NaN())
-  , crt_HitTime(std::numeric_limits<float>::signaling_NaN())
-{
-}
+
+  SRCRUMBSTPCVars::SRCRUMBSTPCVars()
+    : crlongtrackhitfrac(std::numeric_limits<float>::signaling_NaN())
+    , crlongtrackdefl(std::numeric_limits<float>::signaling_NaN())
+    , crlongtrackdiry(std::numeric_limits<float>::signaling_NaN())
+    , crnhitsmax(std::numeric_limits<int>::max())
+    , nusphereeigenratio(std::numeric_limits<float>::signaling_NaN())
+    , nufinalstatepfos(std::numeric_limits<int>::max())
+    , nutotalhits(std::numeric_limits<int>::max())
+    , nuspherespacepoints(std::numeric_limits<int>::max())
+    , nuvertexy(std::numeric_limits<float>::signaling_NaN())
+    , nuwgtdirz(std::numeric_limits<float>::signaling_NaN())
+    , stoppingchi2ratio(std::numeric_limits<float>::signaling_NaN())
+  {
+  }
+
+  SRCRUMBSPDSVars::SRCRUMBSPDSVars()
+    : fmtotalscore(std::numeric_limits<float>::signaling_NaN())
+    , fmpe(std::numeric_limits<float>::signaling_NaN())
+    , fmtime(std::numeric_limits<float>::signaling_NaN())
+  {
+  }
+
+  SRCRUMBSCRTVars::SRCRUMBSCRTVars()
+    : trackscore(std::numeric_limits<float>::signaling_NaN())
+    , hitscore(std::numeric_limits<float>::signaling_NaN())
+    , tracktime(std::numeric_limits<float>::signaling_NaN())
+    , hittime(std::numeric_limits<float>::signaling_NaN())
+  {
+  }
+
+  SRCRUMBSResult::SRCRUMBSResult()
+    : score(std::numeric_limits<float>::signaling_NaN())
+    , tpc()
+    , pds()
+    , crt()
+  {
+  }
 
 } // end namespace
 //////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -4,9 +4,6 @@
 #ifndef SRCRUMBSRESULT_H
 #define SRCRUMBSRESULT_H
 
-
-#include <vector>
-
 namespace caf {
 /// Representation of CRUMBS MVA Slice ID output
 class SRCRUMBSResult {

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -11,25 +11,25 @@ class SRCRUMBSResult {
   SRCRUMBSResult();
   ~SRCRUMBSResult() {}
 
-  float score;
-  float tpc_CRFracHitsInLongestTrack;
-  float tpc_CRLongestTrackDeflection;
-  float tpc_CRLongestTrackDirY;
-  int   tpc_CRNHitsMax;
-  float tpc_NuEigenRatioInSphere;
-  int   tpc_NuNFinalStatePfos;
-  int   tpc_NuNHitsTotal;
-  int   tpc_NuNSpacePointsInSphere;
-  float tpc_NuVertexY;
-  float tpc_NuWeightedDirZ;
-  float tpc_StoppingChi2CosmicRatio;
-  float pds_FMTotalScore;
-  float pds_FMPE;
-  float pds_FMTime;
-  float crt_TrackScore;
-  float crt_HitScore;
-  float crt_TrackTime;
-  float crt_HitTime;
+  float score;                         //!< CRUMBS result
+  float tpc_CRFracHitsInLongestTrack;  //!< fraction of slice’s space points in longest track (cosmic reco)
+  float tpc_CRLongestTrackDeflection;  //!< 1 - the cosine of the angle between the starting and finishing directions of the longest track (cosmic reco)
+  float tpc_CRLongestTrackDirY;        //!< relative direction of the longest track in Y (cosmic reco)
+  int   tpc_CRNHitsMax;                //!< the number of space points in the largest pfp
+  float tpc_NuEigenRatioInSphere;      //!< the ratio between the first and second eigenvalues from a PCA of spacepoints within 10cm of the vertex (nu reco)
+  int   tpc_NuNFinalStatePfos;         //!< the number of final state pfos (nu reco)
+  int   tpc_NuNHitsTotal;              //!< the total number of space points (nu reco)
+  int   tpc_NuNSpacePointsInSphere;    //!< the total number of space points within 10cm of the vertex (nu reco)
+  float tpc_NuVertexY;                 //!< the vertex position in Y (nu reco) [cm]
+  float tpc_NuWeightedDirZ;            //!< the Z component of the space-point weighted direction of the final state pfos (nu reco)
+  float tpc_StoppingChi2CosmicRatio;   //!< a ratio of chi2 values intended to find Bragg peaks in stopping muon tracks
+  float pds_FMTotalScore;              //!< the total flash match score
+  float pds_FMPE;                      //!< the total number of photoelectrons in the associated flash
+  float pds_FMTime;                    //!< the time associated with the flash [us]
+  float crt_TrackScore;                //!< a combination of the DCA and angle between the best matched TPC & CRT tracks
+  float crt_HitScore;                  //!< the best distance from an extrapolated TPC track to a CRT hit [cm]
+  float crt_TrackTime;                 //!< the time associated with the matched CRT track [us]
+  float crt_HitTime;                   //!< the time associated with the matched CRT hit [us]
 };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -31,6 +31,8 @@ class SRCRUMBSResult {
   float pds_FMTime;
   float crt_TrackScore;
   float crt_HitScore;
+  float crt_TrackTime;
+  float crt_HitTime;
 };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -18,11 +18,11 @@ class SRCRUMBSResult {
   float tpc_CRFracHitsInLongestTrack;
   float tpc_CRLongestTrackDeflection;
   float tpc_CRLongestTrackDirY;
-  float tpc_CRNHitsMax;
+  int   tpc_CRNHitsMax;
   float tpc_NuEigenRatioInSphere;
-  float tpc_NuNFinalStatePfos;
-  float tpc_NuNHitsTotal;
-  float tpc_NuNSpacePointsInSphere;
+  int   tpc_NuNFinalStatePfos;
+  int   tpc_NuNHitsTotal;
+  int   tpc_NuNSpacePointsInSphere;
   float tpc_NuVertexY;
   float tpc_NuWeightedDirZ;
   float tpc_StoppingChi2CosmicRatio;

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -5,32 +5,61 @@
 #define SRCRUMBSRESULT_H
 
 namespace caf {
-/// Representation of CRUMBS MVA Slice ID output
-class SRCRUMBSResult {
-  public:
-  SRCRUMBSResult();
-  ~SRCRUMBSResult() {}
+  
+  //!< TPC input variables for CRUMBS
+  class SRCRUMBSTPCVars {
+  public: 
+    SRCRUMBSTPCVars();
+    ~SRCRUMBSTPCVars() {}
 
-  float score;                         //!< CRUMBS result
-  float tpc_CRFracHitsInLongestTrack;  //!< fraction of slice’s space points in longest track (cosmic reco)
-  float tpc_CRLongestTrackDeflection;  //!< 1 - the cosine of the angle between the starting and finishing directions of the longest track (cosmic reco)
-  float tpc_CRLongestTrackDirY;        //!< relative direction of the longest track in Y (cosmic reco)
-  int   tpc_CRNHitsMax;                //!< the number of space points in the largest pfp
-  float tpc_NuEigenRatioInSphere;      //!< the ratio between the first and second eigenvalues from a PCA of spacepoints within 10cm of the vertex (nu reco)
-  int   tpc_NuNFinalStatePfos;         //!< the number of final state pfos (nu reco)
-  int   tpc_NuNHitsTotal;              //!< the total number of space points (nu reco)
-  int   tpc_NuNSpacePointsInSphere;    //!< the total number of space points within 10cm of the vertex (nu reco)
-  float tpc_NuVertexY;                 //!< the vertex position in Y (nu reco) [cm]
-  float tpc_NuWeightedDirZ;            //!< the Z component of the space-point weighted direction of the final state pfos (nu reco)
-  float tpc_StoppingChi2CosmicRatio;   //!< a ratio of chi2 values intended to find Bragg peaks in stopping muon tracks
-  float pds_FMTotalScore;              //!< the total flash match score
-  float pds_FMPE;                      //!< the total number of photoelectrons in the associated flash
-  float pds_FMTime;                    //!< the time associated with the flash [us]
-  float crt_TrackScore;                //!< a combination of the DCA and angle between the best matched TPC & CRT tracks
-  float crt_HitScore;                  //!< the best distance from an extrapolated TPC track to a CRT hit [cm]
-  float crt_TrackTime;                 //!< the time associated with the matched CRT track [us]
-  float crt_HitTime;                   //!< the time associated with the matched CRT hit [us]
-};
+    float crlongtrackhitfrac;        //!< fraction of slice’s space points in longest track (cosmic reco)
+    float crlongtrackdefl;           //!< 1 - the cosine of the angle between the starting and finishing directions of the longest track (cosmic reco)
+    float crlongtrackdiry;           //!< relative direction of the longest track in Y (cosmic reco)
+    int   crnhitsmax;                //!< the number of space points in the largest pfp
+    float nusphereeigenratio;        //!< the ratio between the first and second eigenvalues from a PCA of spacepoints within 10cm of the vertex (nu reco)
+    int   nufinalstatepfos;          //!< the number of final state pfos (nu reco)
+    int   nutotalhits;               //!< the total number of space points (nu reco)
+    int   nuspherespacepoints;       //!< the total number of space points within 10cm of the vertex (nu reco)
+    float nuvertexy;                 //!< the vertex position in Y (nu reco) [cm]
+    float nuwgtdirz;                 //!< the Z component of the space-point weighted direction of the final state pfos (nu reco)
+    float stoppingchi2ratio;         //!< a ratio of chi2 values intended to find Bragg peaks in stopping muon tracks  
+  };
+
+  //!< PDS input variables for CRUMBS
+  class SRCRUMBSPDSVars {
+  public:
+    SRCRUMBSPDSVars();
+    ~SRCRUMBSPDSVars() {}
+
+    float fmtotalscore;              //!< the total flash match score
+    float fmpe;                      //!< the total number of photoelectrons in the associated flash
+    float fmtime;                    //!< the time associated with the flash [us]
+  };
+
+  //!< CRT input variables for CRUMBS
+  class SRCRUMBSCRTVars {
+  public:
+    SRCRUMBSCRTVars();
+    ~SRCRUMBSCRTVars() {}
+
+    float trackscore;                //!< a combination of the DCA and angle between the best matched TPC & CRT tracks
+    float hitscore;                  //!< the best distance from an extrapolated TPC track to a CRT hit [cm]
+    float tracktime;                 //!< the time associated with the matched CRT track [us]
+    float hittime;                   //!< the time associated with the matched CRT hit [us]
+  };
+
+  //!< Result of the CRUMBS slice ID MVA
+  class SRCRUMBSResult {
+  public:
+    SRCRUMBSResult();
+    ~SRCRUMBSResult() {}
+
+    float score;                         //!< CRUMBS result
+  
+    SRCRUMBSTPCVars tpc;                 //!< TPC input variables
+    SRCRUMBSPDSVars pds;                 //!< PDS input variables
+    SRCRUMBSCRTVars crt;                 //!< CRT input variables
+  };
 
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRCRUMBSResult.h
+////////////////////////////////////////////////////////////////////////
+#ifndef SRCRUMBSRESULT_H
+#define SRCRUMBSRESULT_H
+
+
+#include <vector>
+
+namespace caf {
+/// Representation of CRUMBS MVA Slice ID output
+class SRCRUMBSResult {
+  public:
+  SRCRUMBSResult();
+  ~SRCRUMBSResult() {}
+
+  float score;
+  float tpc_CRFracHitsInLongestTrack;
+  float tpc_CRLongestTrackDeflection;
+  float tpc_CRLongestTrackDirY;
+  float tpc_CRNHitsMax;
+  float tpc_NuEigenRatioInSphere;
+  float tpc_NuNFinalStatePfos;
+  float tpc_NuNHitsTotal;
+  float tpc_NuNSpacePointsInSphere;
+  float tpc_NuVertexY;
+  float tpc_NuWeightedDirZ;
+  float tpc_StoppingChi2CosmicRatio;
+  float pds_FMTotalScore;
+  float pds_FMPE;
+  float pds_FMTime;
+  float crt_TrackScore;
+  float crt_HitScore;
+};
+
+} // end namespace
+
+#endif // SRCRUMBSRESULT_H
+//////////////////////////////////////////////////////////////////////////////
+

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -17,6 +17,7 @@ namespace caf
     is_clear_cosmic(false),
     nu_pdg(INT_MIN),
     nu_score(std::numeric_limits<float>::signaling_NaN()),
+    crumbs_result(std::numeric_limits<float>::signaling_NaN()),
     self(INT_MIN)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -17,7 +17,6 @@ namespace caf
     is_clear_cosmic(false),
     nu_pdg(INT_MIN),
     nu_score(std::numeric_limits<float>::signaling_NaN()),
-    crumbs_result(std::numeric_limits<float>::signaling_NaN()),
     self(INT_MIN)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -38,8 +38,10 @@ namespace caf
       SRFakeReco fake_reco;
 
       bool is_clear_cosmic; //!< Whether pandora marks the slice as a "clear" cosmic
-      int nu_pdg; //!< PDG assigned to the PFParticle Neutrino
-      float nu_score; //!< Score of how neutrino-like the slice is
+      int nu_pdg;           //!< PDG assigned to the PFParticle Neutrino
+      float nu_score;       //!< Score of how neutrino-like the slice is according to pandora
+      float crumbs_result;  //!< Score of how neutrino-like the slice is according to the CRUMBS ID
+
       std::vector<size_t> primary; //!< ID's of primary tracks and showers in slice
       int                 self;    //!< ID of the particle representing this slice
 

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -6,6 +6,7 @@
 #ifndef SRSLICE_H
 #define SRSLICE_H
 
+#include "sbnanaobj/StandardRecord/SRCRUMBSResult.h"
 #include "sbnanaobj/StandardRecord/SRFakeReco.h"
 #include "sbnanaobj/StandardRecord/SRFlashMatch.h"
 #include "sbnanaobj/StandardRecord/SRSliceRecoBranch.h"
@@ -37,10 +38,10 @@ namespace caf
 
       SRFakeReco fake_reco;
 
-      bool is_clear_cosmic; //!< Whether pandora marks the slice as a "clear" cosmic
-      int nu_pdg;           //!< PDG assigned to the PFParticle Neutrino
-      float nu_score;       //!< Score of how neutrino-like the slice is according to pandora
-      float crumbs_result;  //!< Score of how neutrino-like the slice is according to the CRUMBS ID
+      bool is_clear_cosmic;          //!< Whether pandora marks the slice as a "clear" cosmic
+      int nu_pdg;                    //!< PDG assigned to the PFParticle Neutrino
+      float nu_score;                //!< Score of how neutrino-like the slice is according to pandora
+      SRCRUMBSResult crumbs_result;  //!< Score of how neutrino-like the slice is according to the CRUMBS ID
 
       std::vector<size_t> primary; //!< ID's of primary tracks and showers in slice
       int                 self;    //!< ID of the particle representing this slice

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -32,8 +32,10 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="14">
-   <version ClassVersion="14" checksum="1378484383"/>
+  <class name="caf::SRSlice" ClassVersion="13">
+   <version ClassVersion="13" checksum="1378484383"/>
+   <version ClassVersion="12" checksum="3783103871"/>
+   <version ClassVersion="11" checksum="3227898381"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -202,8 +202,8 @@
    <version ClassVersion="10" checksum="2143749817"/>
   </class>
 
-  <class name="caf::SRCRUMBSResult" ClassVersion="11">
-   <version ClassVersion="11" checksum="2856367835"/>
+  <class name="caf::SRCRUMBSResult" ClassVersion="12">
+   <version ClassVersion="12" checksum="511805423"/>
   </class>
 
   <!--<class name="caf::SRLorentzVector" /> -->

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -204,9 +204,20 @@
    <version ClassVersion="10" checksum="2143749817"/>
   </class>
 
-  <class name="caf::SRCRUMBSResult" ClassVersion="13">
-   <version ClassVersion="13" checksum="1781332055"/>
-   <version ClassVersion="12" checksum="511805423"/>
+  <class name="caf::SRCRUMBSResult" ClassVersion="10">
+   <version ClassVersion="10" checksum="783958853"/>
+  </class>
+
+  <class name="caf::SRCRUMBSTPCVars" ClassVersion="10">
+   <version ClassVersion="10" checksum="1693619771"/>
+  </class>
+
+  <class name="caf::SRCRUMBSPDSVars" ClassVersion="10">
+   <version ClassVersion="10" checksum="2282974103"/>
+  </class>
+
+  <class name="caf::SRCRUMBSCRTVars" ClassVersion="10">
+   <version ClassVersion="10" checksum="1010873394"/>
   </class>
 
   <!--<class name="caf::SRLorentzVector" /> -->

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -202,7 +202,8 @@
    <version ClassVersion="10" checksum="2143749817"/>
   </class>
 
-  <class name="caf::SRCRUMBSResult" ClassVersion="12">
+  <class name="caf::SRCRUMBSResult" ClassVersion="13">
+   <version ClassVersion="13" checksum="1781332055"/>
    <version ClassVersion="12" checksum="511805423"/>
   </class>
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -32,8 +32,8 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="13">
-   <version ClassVersion="13" checksum="3523757735"/>
+  <class name="caf::SRSlice" ClassVersion="14">
+   <version ClassVersion="14" checksum="1378484383"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">
@@ -202,6 +202,10 @@
    <version ClassVersion="10" checksum="2143749817"/>
   </class>
 
+  <class name="caf::SRCRUMBSResult" ClassVersion="11">
+   <version ClassVersion="11" checksum="2856367835"/>
+  </class>
+
   <!--<class name="caf::SRLorentzVector" /> -->
 
   <class name="std::vector<caf::SRSlice>" />
@@ -224,6 +228,7 @@
   <class name="std::vector<caf::SRStubHit>" />
   <class name="std::vector<caf::SRStubPlane>" />
   <class name="std::vector<caf::SRBNBInfo>" />
+  <class name="std::vector<caf::SRCRUMBSResult>" />
 
   <class name="caf::SRCRTHit" ClassVersion="10">
    <version ClassVersion="10" checksum="3162534166"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -32,9 +32,8 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="12">
-   <version ClassVersion="12" checksum="3783103871"/>
-   <version ClassVersion="11" checksum="3227898381"/>
+  <class name="caf::SRSlice" ClassVersion="13">
+   <version ClassVersion="13" checksum="3523757735"/>
   </class>
 
   <class name="caf::SRFlashMatch" ClassVersion="11">


### PR DESCRIPTION
Creates a standard record object SRCRUMBSResult to store the result of CRUMBS's BDT in the CAF files.

Links to main PR https://github.com/SBNSoftware/sbncode/pull/250