### PR TITLE
Add enums to classes_def

### DIFF
--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -272,13 +272,19 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
-  <enum name="caf::Plane_t" ClassVersion="10"/>
   <enum name="caf::Det_t" ClassVersion="10"/>
-  <enum name="caf::MCType_t" ClassVersion="10"/>
+  <enum name="caf::Plane_t" ClassVersion="10"/>
   <enum name="caf::Wall_t" ClassVersion="10"/>
+  <enum name="caf::MCType_t" ClassVersion="10"/>
   <enum name="caf::generator_" ClassVersion="10"/>
   <enum name="caf::mevprtlchannel_" ClassVersion="10"/>
-  <enum name="caf::interaction_mode_" ClassVersion="10"/>
+  <enum name="caf::genie_interaction_mode_" ClassVersion="10"/>
+  <enum name="caf::genie_interaction_type_" ClassVersion="10"/>
   <enum name="caf::genie_status_" ClassVersion="10"/>
   <enum name="caf::g4_process_" ClassVersion="10"/>
+  <enum name="caf::ReweightType_t" ClassVersion="10"/>
+
+  <!-- Kept for now as a deprecated name, may be needed for opening old files -->
+  <enum name="caf::interaction_mode_" ClassVersion="10"/>
+
 </lcgdict>


### PR DESCRIPTION
Re discussion in the PAT meeting this afternoon.

This is a non-critical PR for SBN2022A. It will make the cafmaker stage more resilient but isn't blocking to commencing production. If there is another more significant bug found at the sbn level then this should be added to the patch, if not it doesn't need it's own patch.

The purpose of this PR is to ensure the right dictionary elements are in place to prevent cafmaker failing when fed a `-o` flag. I will make a corresponding PR for develop that will do the same and should be merged.