### PR TITLE
Update to sproxy v00.34

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,7 @@ fwdir   product_dir scripts
 
 product             version
 root                v6_22_08d
-srproxy             v00.32
+srproxy             v00.34
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers


### PR DESCRIPTION
This release fixes the miss-indexing issue that is the root cause of the pre-production proton PID problem