### PR TITLE
Upgrade to srproxy v00.35

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,7 @@ fwdir   product_dir scripts
 
 product             version
 root                v6_22_08d
-srproxy             v00.34
+srproxy             v00.35
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers


### PR DESCRIPTION
Fixes the problem with missing nfoo fields that affects the spill counting.