### PR TITLE
Initialise contained variable

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTHit.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTHit.cxx
@@ -11,6 +11,8 @@ namespace caf
 
   SRCRTHit::SRCRTHit():
     time(std::numeric_limits<float>::signaling_NaN()),
+    t0(std::numeric_limits<float>::signaling_NaN()),
+    t1(std::numeric_limits<float>::signaling_NaN()),
     pe(std::numeric_limits<float>::signaling_NaN()),
     plane(INT_MIN)
   {}

--- a/sbnanaobj/StandardRecord/SRFakeRecoParticle.cxx
+++ b/sbnanaobj/StandardRecord/SRFakeRecoParticle.cxx
@@ -14,7 +14,8 @@ namespace caf
     ke(std::numeric_limits<float>::signaling_NaN()),
     costh(std::numeric_limits<float>::signaling_NaN()),
     len(std::numeric_limits<float>::signaling_NaN()),
-    pid(-999)
+    pid(-999),
+    contained(false)
   {  }
 
 } // end namespace caf


### PR DESCRIPTION
Getting around to making a PR for a branch I made ages ago. Picked up in the debug builds of the CI this variable isn't initialised and so can have undefined behaviour when not filled. This makes the CI think it has changed value.