### PR TITLE
Feature/rh test caf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 
 find_package(cetmodules 3.20.00 REQUIRED)
-project(sbnanaobj VERSION 09.20.00 LANGUAGES CXX)
+project(sbnanaobj VERSION 09.20.00.01 LANGUAGES CXX)
 
 message(STATUS "\n\n  ==========================   ${PROJECT_NAME}   ==========================")
 

--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -15,13 +15,17 @@ namespace caf
     time(std::numeric_limits<float>::signaling_NaN()),
     chargeQ(std::numeric_limits<float>::signaling_NaN()),
     chargeCenter(SRVector3D()),
+    chargeWidth(SRVector3D()),
     lightPE(std::numeric_limits<float>::signaling_NaN()),
     lightCenter(SRVector3D()),
+    lightWidth(SRVector3D()),
     score(std::numeric_limits<float>::signaling_NaN()),
     scoreY(std::numeric_limits<float>::signaling_NaN()),
     scoreZ(std::numeric_limits<float>::signaling_NaN()),
     scoreRR(std::numeric_limits<float>::signaling_NaN()),
-    scoreRatio(std::numeric_limits<float>::signaling_NaN())
+    scoreRatio(std::numeric_limits<float>::signaling_NaN()),
+    scoreSlope(std::numeric_limits<float>::signaling_NaN()),
+    scorePEToQ(std::numeric_limits<float>::signaling_NaN())
   {}
 
   SRFlashMatch::~SRFlashMatch(){  }
@@ -37,6 +41,8 @@ namespace caf
     scoreZ     = -5.0;
     scoreRR    = -5.0;
     scoreRatio = -5.0;
+    scoreSlope = -5.0;
+    scorePEToQ = -5.0;
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -22,13 +22,17 @@ namespace caf
       float time;                //!< time of flash
       float chargeQ;             //!< charge in slc
       SRVector3D chargeCenter;   //!< Weighted center position [cm]
+      SRVector3D chargeWidth;    //!< Weighted width [cm]
       float lightPE;             //!< photo-electrons on simple flash
       SRVector3D lightCenter;    //!< Weighted center position [cm]
+      SRVector3D lightWidth;     //!< Weighted width [cm]
       float score;               //!< total score, sum of terms
       float scoreY;              //!< score for y metric
       float scoreZ;              //!< score for z metric
       float scoreRR;             //!< score for rr metric
       float scoreRatio;          //!< score for ratio metric
+      float scoreSlope;          //!< score for z/y slope metric
+      float scorePEToQ;          //!< score for light/charge quotient metric
 
       void setDefault();
     };

--- a/sbnanaobj/StandardRecord/SRPFP.h
+++ b/sbnanaobj/StandardRecord/SRPFP.h
@@ -30,8 +30,8 @@ class SRPFP {
   int slcID; // ID of the slice that this PFP belongs to
   float t0; // T0 assigned by TPC reco, if any
 
-  SRTrack trk;
-  SRShower shw;
+  SRTrack trk; // Track reconstructed from this PFP
+  SRShower shw; // Shower reoconstructed from this PFP
 };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/SRPFP.h
+++ b/sbnanaobj/StandardRecord/SRPFP.h
@@ -5,6 +5,8 @@
 #define SRPFP_H
 
 #include "sbnanaobj/StandardRecord/SRPFOChar.h"
+#include "sbnanaobj/StandardRecord/SRTrack.h"
+#include "sbnanaobj/StandardRecord/SRShower.h"
 
 #include <vector>
 
@@ -27,6 +29,9 @@ class SRPFP {
 
   int slcID; // ID of the slice that this PFP belongs to
   float t0; // T0 assigned by TPC reco, if any
+
+  SRTrack trk;
+  SRShower shw;
 };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/SRShower.h
+++ b/sbnanaobj/StandardRecord/SRShower.h
@@ -7,7 +7,7 @@
 #include "sbnanaobj/StandardRecord/SRVector3D.h"
 #include "sbnanaobj/StandardRecord/SRShowerSelection.h"
 #include "sbnanaobj/StandardRecord/SRTrackTruth.h"
-#include "sbnanaobj/StandardRecord/SRPFP.h"
+//#include "sbnanaobj/StandardRecord/SRPFP.h"
 #include "sbnanaobj/StandardRecord/SRShowerRazzle.h"
 
 namespace caf
@@ -43,7 +43,7 @@ namespace caf
       SRVector3D end;               ///< shower end point (start+len*dir) in detector coordinates [cm]
       float cosmicDist;             ///< Distance of closest approach to cosmic ray [cm]
 
-      SRPFP pfp;          ///< Contains the hierarchy and metadata from Pandora
+//      SRPFP pfp;          ///< Contains the hierarchy and metadata from Pandora
 
       SRShowerRazzle razzle; ///< Results from the shower PID MVA
       SRShowerSelection selVars;

--- a/sbnanaobj/StandardRecord/SRShower.h
+++ b/sbnanaobj/StandardRecord/SRShower.h
@@ -7,7 +7,6 @@
 #include "sbnanaobj/StandardRecord/SRVector3D.h"
 #include "sbnanaobj/StandardRecord/SRShowerSelection.h"
 #include "sbnanaobj/StandardRecord/SRTrackTruth.h"
-//#include "sbnanaobj/StandardRecord/SRPFP.h"
 #include "sbnanaobj/StandardRecord/SRShowerRazzle.h"
 
 namespace caf
@@ -42,8 +41,6 @@ namespace caf
       SRVector3D start;             ///< shower start point in detector coordinates [cm]
       SRVector3D end;               ///< shower end point (start+len*dir) in detector coordinates [cm]
       float cosmicDist;             ///< Distance of closest approach to cosmic ray [cm]
-
-//      SRPFP pfp;          ///< Contains the hierarchy and metadata from Pandora
 
       SRShowerRazzle razzle; ///< Results from the shower PID MVA
       SRShowerSelection selVars;

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
@@ -9,6 +9,7 @@ namespace caf
 {
   
   SRSliceRecoBranch::SRSliceRecoBranch() :
+    nstub(0),
     npfp(0)
   {  
   }

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
@@ -21,6 +21,10 @@ namespace caf
   void SRSliceRecoBranch::fillSizes()
   {
     npfp   = pfp.size();
+    //    nvtx   = vtx.size();
+    nhit   = hit.size();
+    // nshw_em = shw_em.size();
+    // nshw_pandora = shw_pandora.size();
   }
  
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
@@ -9,8 +9,8 @@ namespace caf
 {
   
   SRSliceRecoBranch::SRSliceRecoBranch() :
-    nstub(0),
-    npfp(0)
+    npfp(0),
+    nstub(0)
   {  
   }
   
@@ -20,7 +20,6 @@ namespace caf
 
   void SRSliceRecoBranch::fillSizes()
   {
-    
     npfp   = pfp.size();
   }
  

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
@@ -9,10 +9,7 @@ namespace caf
 {
   
   SRSliceRecoBranch::SRSliceRecoBranch() :
-    ntrk(0),
-    nshw(0),
-    nhit(0),
-    nstub(0)
+    npfp(0)
   {  
   }
   
@@ -23,13 +20,7 @@ namespace caf
   void SRSliceRecoBranch::fillSizes()
   {
     
-    //    nvtx   = vtx.size();
-    ntrk   = trk.size();
-    nshw   = shw.size();
-    nhit   = hit.size();
-    // nshw_em = shw_em.size();
-    // nshw_pandora = shw_pandora.size();
-
+    npfp   = pfp.size();
   }
  
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.cxx
@@ -10,6 +10,7 @@ namespace caf
   
   SRSliceRecoBranch::SRSliceRecoBranch() :
     npfp(0),
+    nhit(0),
     nstub(0)
   {  
   }

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -9,6 +9,7 @@
 #include "sbnanaobj/StandardRecord/SRPFP.h"
 
 #include <vector>
+#include <unordered_map>
 
 namespace caf
 {
@@ -21,7 +22,7 @@ namespace caf
     
     std::vector<SRPFP> pfp;        ///< Vector of pfps
     size_t             npfp;       ///< Number of pfps
-   
+            
     std::vector<SRHit> hit;        ///< Vector of hits
     size_t            nhit;        ///< Number of hits
  

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -7,7 +7,6 @@
 #include "sbnanaobj/StandardRecord/SRStub.h"
 #include "sbnanaobj/StandardRecord/SRHit.h"
 #include "sbnanaobj/StandardRecord/SRPFP.h"
->>>>>>> 2d13569 (Removed tracks and showers and added PFPs to the SRSliceRecoBranch, and added a shower and track to SRPFPs.)
 
 #include <vector>
 

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -21,7 +21,10 @@ namespace caf
     
     std::vector<SRPFP> pfp;        ///< Vector of pfps
     size_t             npfp;       ///< Number of pfps
-    
+   
+    std::vector<SRHit> hit;        ///< Vector of hits
+    size_t            nhit;        ///< Number of hits
+ 
     std::vector<SRStub> stub;      ///< Vector of stubs
     size_t             nstub;      ///< Number of stubs
 

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -4,10 +4,12 @@
 #ifndef SRSLICERECOBRANCH_H
 #define SRSLICERECOBRANCH_H
 
-#include "sbnanaobj/StandardRecord/SRTrack.h"
-#include "sbnanaobj/StandardRecord/SRShower.h"
+//#include "sbnanaobj/StandardRecord/SRTrack.h"
+//#include "sbnanaobj/StandardRecord/SRShower.h"
 #include "sbnanaobj/StandardRecord/SRStub.h"
 #include "sbnanaobj/StandardRecord/SRHit.h"
+#include "sbnanaobj/StandardRecord/SRPFP.h"
+>>>>>>> 2d13569 (Removed tracks and showers and added PFPs to the SRSliceRecoBranch, and added a shower and track to SRPFPs.)
 
 #include <vector>
 
@@ -19,16 +21,9 @@ namespace caf
   public:
     SRSliceRecoBranch();
     ~SRSliceRecoBranch();
-            
-    std::vector<SRTrack>  trk;     ///< Vector of pandora tracks
-    size_t               ntrk;     ///< Number of panora tracks
 
-    std::vector<SRShower> shw;     ///< Vector of trac showers
-    size_t               nshw;     ///< Number of trac showers
-
-    std::vector<SRHit> hit;        ///< Vector of hits
-    size_t            nhit;        ///< Number of hits
-
+    std::vector<SRPFP> pfp;
+    size_t             npfp;            
     std::vector<SRStub> stub;      ///< Vector of stubs
     size_t             nstub;      ///< Number of stubs
 

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -21,15 +21,18 @@ namespace caf
     ~SRSliceRecoBranch();
             
     std::vector<SRTrack>  trk;     ///< Vector of pandora tracks
+    std::unordered_map<int, std:vector<SRTrack>> trkMap;
     size_t               ntrk;     ///< Number of panora tracks
 
     std::vector<SRShower> shw;     ///< Vector of trac showers
+    std::unordered_map<int, std:vector<SRShower>> shwMap;
     size_t               nshw;     ///< Number of trac showers
 
     std::vector<SRHit> hit;        ///< Vector of hits
     size_t            nhit;        ///< Number of hits
 
     std::vector<SRStub> stub;      ///< Vector of stubs
+    std::unordered_map<int, std:vector<SRStub>> stubMap;
     size_t             nstub;      ///< Number of stubs
 
     void fillSizes();

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -10,7 +10,6 @@
 #include "sbnanaobj/StandardRecord/SRHit.h"
 
 #include <vector>
-#include <unordered_map>
 
 namespace caf
 {
@@ -22,11 +21,9 @@ namespace caf
     ~SRSliceRecoBranch();
             
     std::vector<SRTrack>  trk;     ///< Vector of pandora tracks
-    std::unordered_map<size_t, SRTrack> trkMap;
     size_t               ntrk;     ///< Number of panora tracks
 
     std::vector<SRShower> shw;     ///< Vector of trac showers
-    std::unordered_map<size_t, SRShower> shwMap;
     size_t               nshw;     ///< Number of trac showers
 
     std::vector<SRHit> hit;        ///< Vector of hits

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -10,6 +10,7 @@
 #include "sbnanaobj/StandardRecord/SRHit.h"
 
 #include <vector>
+#include <unordered_map>
 
 namespace caf
 {
@@ -21,18 +22,17 @@ namespace caf
     ~SRSliceRecoBranch();
             
     std::vector<SRTrack>  trk;     ///< Vector of pandora tracks
-    std::unordered_map<int, std:vector<SRTrack>> trkMap;
+    std::unordered_map<size_t, SRTrack> trkMap;
     size_t               ntrk;     ///< Number of panora tracks
 
     std::vector<SRShower> shw;     ///< Vector of trac showers
-    std::unordered_map<int, std:vector<SRShower>> shwMap;
+    std::unordered_map<size_t, SRShower> shwMap;
     size_t               nshw;     ///< Number of trac showers
 
     std::vector<SRHit> hit;        ///< Vector of hits
     size_t            nhit;        ///< Number of hits
 
     std::vector<SRStub> stub;      ///< Vector of stubs
-    std::unordered_map<int, std:vector<SRStub>> stubMap;
     size_t             nstub;      ///< Number of stubs
 
     void fillSizes();

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -4,8 +4,6 @@
 #ifndef SRSLICERECOBRANCH_H
 #define SRSLICERECOBRANCH_H
 
-//#include "sbnanaobj/StandardRecord/SRTrack.h"
-//#include "sbnanaobj/StandardRecord/SRShower.h"
 #include "sbnanaobj/StandardRecord/SRStub.h"
 #include "sbnanaobj/StandardRecord/SRHit.h"
 #include "sbnanaobj/StandardRecord/SRPFP.h"
@@ -21,9 +19,10 @@ namespace caf
   public:
     SRSliceRecoBranch();
     ~SRSliceRecoBranch();
-
-    std::vector<SRPFP> pfp;
-    size_t             npfp;            
+    
+    std::vector<SRPFP> pfp;        ///< Vector of pfps
+    size_t             npfp;       ///< Number of pfps
+    
     std::vector<SRStub> stub;      ///< Vector of stubs
     size_t             nstub;      ///< Number of stubs
 

--- a/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
+++ b/sbnanaobj/StandardRecord/SRSliceRecoBranch.h
@@ -9,7 +9,6 @@
 #include "sbnanaobj/StandardRecord/SRPFP.h"
 
 #include <vector>
-#include <unordered_map>
 
 namespace caf
 {

--- a/sbnanaobj/StandardRecord/SRStub.h
+++ b/sbnanaobj/StandardRecord/SRStub.h
@@ -7,6 +7,7 @@
 #include "sbnanaobj/StandardRecord/SRVector3D.h"
 #include "sbnanaobj/StandardRecord/SREnums.h"
 #include "sbnanaobj/StandardRecord/SRTrackTruth.h"
+#include "sbnanaobj/StandardRecord/SRPFP.h"
 
 #include <vector>
 

--- a/sbnanaobj/StandardRecord/SRStub.h
+++ b/sbnanaobj/StandardRecord/SRStub.h
@@ -7,7 +7,6 @@
 #include "sbnanaobj/StandardRecord/SRVector3D.h"
 #include "sbnanaobj/StandardRecord/SREnums.h"
 #include "sbnanaobj/StandardRecord/SRTrackTruth.h"
-#include "sbnanaobj/StandardRecord/SRPFP.h"
 
 #include <vector>
 

--- a/sbnanaobj/StandardRecord/SRTrack.cxx
+++ b/sbnanaobj/StandardRecord/SRTrack.cxx
@@ -21,7 +21,6 @@ namespace caf
     len(kInvalid),
     costh(kInvalid),
     phi(kInvalid)
-//    ID(INT_MIN)
   {
   }
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRTrack.cxx
+++ b/sbnanaobj/StandardRecord/SRTrack.cxx
@@ -20,8 +20,8 @@ namespace caf
     npts(-1),
     len(kInvalid),
     costh(kInvalid),
-    phi(kInvalid),
-    ID(INT_MIN)
+    phi(kInvalid)
+//    ID(INT_MIN)
   {
   }
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRTrack.h
+++ b/sbnanaobj/StandardRecord/SRTrack.h
@@ -13,7 +13,6 @@
 #include "sbnanaobj/StandardRecord/SRCRTHitMatch.h"
 #include "sbnanaobj/StandardRecord/SRCRTTrackMatch.h"
 #include "sbnanaobj/StandardRecord/SRTrackCalo.h"
-//#include "sbnanaobj/StandardRecord/SRPFP.h"
 #include "sbnanaobj/StandardRecord/SRTrackDazzle.h"
 #include "sbnanaobj/StandardRecord/SRTrackScatterClosestApproach.h"
 #include "sbnanaobj/StandardRecord/SRTrackStoppingChi2Fit.h"
@@ -42,7 +41,6 @@ namespace caf
       SRVector3D     dir_end;     ///< Direction of track at end
       SRVector3D     start;       ///< Start point of track
       SRVector3D     end;         ///< End point of track
- //     int            ID;          ///< ID of this track (taken from the pandora particle "ID" of this track)
 
       SRTrkChi2PID chi2pid[3]; ///< Per-plane Chi2 Particle ID
       SRTrackCalo calo[3]; ///< Per-plane Calorimetry information
@@ -54,7 +52,6 @@ namespace caf
       SRTrackTruth   truth;        ///< truth information
       SRCRTHitMatch  crthit;       ///< CRT Hit match
       SRCRTTrackMatch  crttrack;   ///< CRT Track match
-//      SRPFP pfp;                   ///< Contains the hierarchy and metadata from Pandora
 
       SRTrackScatterClosestApproach scatterClosestApproach; ///< Scattering variables relating to spread about interpolated track
       SRTrackStoppingChi2Fit stoppingChi2Fit;               ///< Fit results from Pol0 and Exp to dEdx vs res. range

--- a/sbnanaobj/StandardRecord/SRTrack.h
+++ b/sbnanaobj/StandardRecord/SRTrack.h
@@ -13,7 +13,7 @@
 #include "sbnanaobj/StandardRecord/SRCRTHitMatch.h"
 #include "sbnanaobj/StandardRecord/SRCRTTrackMatch.h"
 #include "sbnanaobj/StandardRecord/SRTrackCalo.h"
-#include "sbnanaobj/StandardRecord/SRPFP.h"
+//#include "sbnanaobj/StandardRecord/SRPFP.h"
 #include "sbnanaobj/StandardRecord/SRTrackDazzle.h"
 #include "sbnanaobj/StandardRecord/SRTrackScatterClosestApproach.h"
 #include "sbnanaobj/StandardRecord/SRTrackStoppingChi2Fit.h"
@@ -42,7 +42,7 @@ namespace caf
       SRVector3D     dir_end;     ///< Direction of track at end
       SRVector3D     start;       ///< Start point of track
       SRVector3D     end;         ///< End point of track
-      int            ID;          ///< ID of this track (taken from the pandora particle "ID" of this track)
+ //     int            ID;          ///< ID of this track (taken from the pandora particle "ID" of this track)
 
       SRTrkChi2PID chi2pid[3]; ///< Per-plane Chi2 Particle ID
       SRTrackCalo calo[3]; ///< Per-plane Calorimetry information
@@ -54,7 +54,7 @@ namespace caf
       SRTrackTruth   truth;        ///< truth information
       SRCRTHitMatch  crthit;       ///< CRT Hit match
       SRCRTTrackMatch  crttrack;   ///< CRT Track match
-      SRPFP pfp;                   ///< Contains the hierarchy and metadata from Pandora
+//      SRPFP pfp;                   ///< Contains the hierarchy and metadata from Pandora
 
       SRTrackScatterClosestApproach scatterClosestApproach; ///< Scattering variables relating to spread about interpolated track
       SRTrackStoppingChi2Fit stoppingChi2Fit;               ///< Fit results from Pol0 and Exp to dEdx vs res. range

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -65,8 +65,9 @@
    <version ClassVersion="11" checksum="1429601394"/>
   </class>
 
-  <class name="caf::SRSliceRecoBranch" ClassVersion="12">
-   <version ClassVersion="12" checksum="2959836900"/>
+  <class name="caf::SRSliceRecoBranch" ClassVersion="13">
+   <version ClassVersion="13" checksum="4211357366"/>
+   <version ClassVersion="12" checksum="1302849020"/>
    <version ClassVersion="11" checksum="1272564698"/>
    <version ClassVersion="10" checksum="1432916981"/>
   </class>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -210,14 +210,10 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
-<<<<<<< HEAD
-  <class name="caf::SRPFP" ClassVersion="12">
+  <class name="caf::SRPFP" ClassVersion="13">
+   <version ClassVersion="13" checksum="2132348118"/>
    <version ClassVersion="12" checksum="2470467174"/>
    <version ClassVersion="11" checksum="1837341006"/>
-=======
-  <class name="caf::SRPFP" ClassVersion="11">
-   <version ClassVersion="11" checksum="4069884459"/>
->>>>>>> e2ea18a (Removed commented out code and added comments.)
    <version ClassVersion="10" checksum="1732359397"/>
   </class>
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -61,7 +61,8 @@
    <version ClassVersion="11" checksum="3227898381"/>
   </class>
 
-  <class name="caf::SRFlashMatch" ClassVersion="11">
+  <class name="caf::SRFlashMatch" ClassVersion="12">
+   <version ClassVersion="12" checksum="2334957166"/>
    <version ClassVersion="11" checksum="1429601394"/>
   </class>
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -41,7 +41,8 @@
    <version ClassVersion="10" checksum="4180347773"/>
   </class>
 
-  <class name="caf::SRShower" ClassVersion="14">
+  <class name="caf::SRShower" ClassVersion="15">
+   <version ClassVersion="15" checksum="3211336966"/>
    <version ClassVersion="14" checksum="3720936031"/>
    <version ClassVersion="13" checksum="150649609"/>
    <version ClassVersion="12" checksum="2025293789"/>
@@ -82,7 +83,8 @@
    <version ClassVersion="10" checksum="3777054621"/>
   </class>
 
-  <class name="caf::SRTrack" ClassVersion="13">
+  <class name="caf::SRTrack" ClassVersion="14">
+   <version ClassVersion="14" checksum="3934033130"/>
    <version ClassVersion="13" checksum="522362999"/>
    <version ClassVersion="12" checksum="3952974887"/>
    <version ClassVersion="11" checksum="1319166397"/>
@@ -206,9 +208,14 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
+<<<<<<< HEAD
   <class name="caf::SRPFP" ClassVersion="12">
    <version ClassVersion="12" checksum="2470467174"/>
    <version ClassVersion="11" checksum="1837341006"/>
+=======
+  <class name="caf::SRPFP" ClassVersion="11">
+   <version ClassVersion="11" checksum="4069884459"/>
+>>>>>>> e2ea18a (Removed commented out code and added comments.)
    <version ClassVersion="10" checksum="1732359397"/>
   </class>
 


### PR DESCRIPTION
I changed the class definitions to accommadate the reco tree structure change.  It goes as slc->reco->pfp->trk instead of slc->reco->trk->pfp. Stubs were left alone since they can exist without any association to a PFP. This request depends on other pull requests in SBNSoftware/sbnana and SBNSoftware/sbncode.

https://github.com/SBNSoftware/sbnana/tree/feature/rh_testCAF
https://github.com/SBNSoftware/sbncode/tree/feature/rh_allPFOs