### PR TITLE
Create SROpFlash

### DIFF
--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SROpFlash.cxx
+// \brief   Adaptation of recob::OpFlash (https://nusoft.fnal.gov/larsoft/doxsvn/html/classrecob_1_1OpFlash.html). This SR code copied/based on other SR objects.
+// \author  jsmedley@fnal.gov
+////////////////////////////////////////////////////////////////////////
+
+#include "sbnanaobj/StandardRecord/SROpFlash.h"
+
+#include <climits>
+
+namespace caf
+{
+//Temporary***
+
+      double Time; //Time on trigger time scale [us].
+      double Timewidth; //Width of the flash in time [us].
+      double AbsTime; //Time by PMT readout clock.
+      
+      double PE; //Number of PE on a give PMT.
+      std::vector<double> PEs; //Number of PE on each PMT.
+      double TotalPE; //Total number of PE across all PMTs.
+      double FastToTotal; //Fast to total light ratio.
+
+      int OnBeamTime; //Is this in time with beam?
+      
+      bool hasXCenter; //Is the estimated center on x direction is available?
+      double XCenter; //Geometric center in x [cm].
+      double XWidth; //Geometric width in x [cm].
+      double YCenter; //Geometric center in y [cm].
+      double YWidth; //Geometric width in y [cm].
+      double ZCenter; //Geometric center in z [cm].
+      double ZWidth; //Geometric width in z [cm].
+
+      std::vector<double> PEs_per_wall;
+      int cryo;
+
+//***
+  SROpFlash::SROpFlash():
+
+    time(std::numeric_limits<double>::signaling_NaN()),
+    t0(std::numeric_limits<double>::signaling_NaN()),
+    t1(std::numeric_limits<double>::signaling_NaN()),
+    pe(std::numeric_limits<double>::signaling_NaN()),
+    plane(INT_MIN)
+  {}
+} // end namespace caf
+////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -10,38 +10,26 @@
 
 namespace caf
 {
-//Temporary***
 
-      double Time; //Time on trigger time scale [us].
-      double Timewidth; //Width of the flash in time [us].
-      double AbsTime; //Time by PMT readout clock.
-      
-      double PE; //Number of PE on a give PMT.
-      std::vector<double> PEs; //Number of PE on each PMT.
-      double TotalPE; //Total number of PE across all PMTs.
-      double FastToTotal; //Fast to total light ratio.
-
-      int OnBeamTime; //Is this in time with beam?
-      
-      bool hasXCenter; //Is the estimated center on x direction is available?
-      double XCenter; //Geometric center in x [cm].
-      double XWidth; //Geometric width in x [cm].
-      double YCenter; //Geometric center in y [cm].
-      double YWidth; //Geometric width in y [cm].
-      double ZCenter; //Geometric center in z [cm].
-      double ZWidth; //Geometric width in z [cm].
-
-      std::vector<double> PEs_per_wall;
-      int cryo;
-
-//***
   SROpFlash::SROpFlash():
-
-    time(std::numeric_limits<double>::signaling_NaN()),
-    t0(std::numeric_limits<double>::signaling_NaN()),
-    t1(std::numeric_limits<double>::signaling_NaN()),
-    pe(std::numeric_limits<double>::signaling_NaN()),
-    plane(INT_MIN)
   {}
+
+  void SROpFlash::setDefault()
+  {
+
+    Time        = -9999.f;
+    TimeWidth   =    -5.f;
+    TotalPE     =    -5.f;
+    FastToTotal =    -5.f;
+    OnBeamTime  =   false;
+    XCenter     = -9999.f;
+    XWidth      =    -5.f;
+    YCenter     = -9999.f;
+    YWidth      =    -5.f;
+    ZCenter     = -9999.f;
+    ZWidth      =    -5.f;
+    Cryo        =      -5;
+  }
+
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -11,7 +11,7 @@
 namespace caf
 {
 
-  SROpFlash::SROpFlash():
+  SROpFlash::SROpFlash()
   {}
 
   void SROpFlash::setDefault()

--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -17,22 +17,21 @@ namespace caf
   void SROpFlash::setDefault()
   {
 
-    Time        = -9999.f;
-    TimeWidth   =    -5.f;
-    TimeMean    =    -5.f;
-    TimeSD      =    -5.f;
-    FirstTime    =    -5.f;
-    TotalPE     =    -5.f;
-    FastToTotal =    -5.f;
-    OnBeamTime  =   false;
-    XCenter     = -9999.f;
-    XWidth      =    -5.f;
-    YCenter     = -9999.f;
-    YWidth      =    -5.f;
-    ZCenter     = -9999.f;
-    ZWidth      =    -5.f;
-    Cryo        =      -5;
-    FirstPMT    =      -5;
+    onbeamtime       =   false;
+    cryo             =      -5;
+    firstpmt         =      -5;
+    time             = -9999.f;
+    timewidth        =    -5.f;
+    timemean         = -9999.f;
+    timesd           =    -5.f;
+    firsttime        = -9999.f;
+    totalpe          =    -5.f;
+    fasttototal      =    -5.f;
+    peperwall[0] = -5.f;
+    peperwall[1] = -5.f;
+
+    center           = SRVector3D(-9999.f, -9999.f, -9999.f);
+    width            = SRVector3D(-9999.f, -9999.f, -9999.f);
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -19,6 +19,9 @@ namespace caf
 
     Time        = -9999.f;
     TimeWidth   =    -5.f;
+    TimeMean    =    -5.f;
+    TimeSD      =    -5.f;
+    FirstTime    =    -5.f;
     TotalPE     =    -5.f;
     FastToTotal =    -5.f;
     OnBeamTime  =   false;
@@ -29,6 +32,7 @@ namespace caf
     ZCenter     = -9999.f;
     ZWidth      =    -5.f;
     Cryo        =      -5;
+    FirstPMT    =      -5;
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SROPFLASH.h
+// \brief   Adaptation of recob::OpFlash (https://nusoft.fnal.gov/larsoft/doxsvn/html/classrecob_1_1OpFlash.html). This SR code copied/based on other SR objects.
+// \author  jsmedley@fnal.gov
+////////////////////////////////////////////////////////////////////////
+#ifndef SROPFLASH_H
+#define SROPFLASH_H
+
+
+namespace caf
+{
+  /// OpFlash
+  class SROpFlash
+    {
+    public:
+
+      SROpFlash();
+
+      virtual ~SROpFlash() {}
+//NOTE: They all have this. Not sure what exactly this does, but it seems necessary.
+
+      double Time; //Time on trigger time scale [us].
+      double Timewidth; //Width of the flash in time [us].
+      double AbsTime; //Time by PMT readout clock.
+
+      double PE; //Number of PE on a give PMT.
+//NOTE: Might not need this? Doesn't make sense to store each entry separately given that we have the vector form.
+      std::vector<double> PEs; //Number of PE on each PMT.
+      double TotalPE; //Total number of PE across all PMTs.
+      double FastToTotal; //Fast to total light ratio.
+
+      bool OnBeamTime; //Is this in time with beam?
+//NOTE: Changed from int to bool. I have a feeling this int was 0/1.
+
+      bool hasXCenter; //Is the estimated center on x direction is available?
+//NOTE: This one's weird. Do we need this? Do some flashes not have X centers?
+      double XCenter; //Geometric center in x [cm].
+      double XWidth; //Geometric width in x [cm].
+      double YCenter; //Geometric center in y [cm].
+      double YWidth; //Geometric width in y [cm].
+      double ZCenter; //Geometric center in z [cm].
+      double ZWidth; //Geometric width in z [cm].
+
+//NOTE: Dropping frame stuff (uBooNE) and wire centers/widths
+
+      std::vector<double> PE_per_wall; //Backhouse's suggestion
+      int cryo; //0 for SBND/ICARUS East, 1 for ICARUS West
+//NOTE: New additions
+
+      void setDefault();
+    };
+
+} // end namespace
+
+#endif // SROPFLASH_H
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -8,6 +8,7 @@
 
 #include "sbnanaobj/StandardRecord/SRConstants.h"
 #include <climits>
+#include <vector>
 
 namespace caf
 {
@@ -19,7 +20,7 @@ namespace caf
 
       bool  OnBeamTime  { false             }; //!< Is this in time with beam?
       float Time        { kSignalingNaN     }; //!< Time on trigger time scale [us].
-      float Timewidth   { kSignalingNaN     }; //!< Width of the flash in time [us].
+      float TimeWidth   { kSignalingNaN     }; //!< Width of the flash in time [us].
       float TotalPE     { kSignalingNaN     }; //!< Total number of PE across all PMTs.
       float FastToTotal { kSignalingNaN     }; //!< Fast to total light ratio.
       float YCenter     { kSignalingNaN     }; //!< Geometric center in y [cm].

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -1,46 +1,41 @@
 ////////////////////////////////////////////////////////////////////////
 // \file    SROPFLASH.h
-// \brief   Adaptation of recob::OpFlash (https://nusoft.fnal.gov/larsoft/doxsvn/html/classrecob_1_1OpFlash.html). This SR code copied/based on other SR objects.
+// \brief   Adaptation of recob::OpFlash (https://nusoft.fnal.gov/larsoft/doxsvn/html/classrecob_1_1OpFlash.html).
 // \author  jsmedley@fnal.gov
 ////////////////////////////////////////////////////////////////////////
 #ifndef SROPFLASH_H
 #define SROPFLASH_H
 
 #include "sbnanaobj/StandardRecord/SRConstants.h"
-#include <climits>
+#include "sbnanaobj/StandardRecord/SRVector3D.h"
 #include <vector>
 
 namespace caf
 {
-  /// OpFlash
+  /// Optical Flash -- a summary of multiple optical hits that have been determined to be associated
   class SROpFlash
-    {
-    public:
-      SROpFlash();
+  {
+  public:
+    SROpFlash();
 
-      bool  OnBeamTime  { false             }; //!< Is this in time with beam?
-      float Time        { kSignalingNaN     }; //!< Time on trigger time scale [us].
-      float TimeWidth   { kSignalingNaN     }; //!< Width of the flash in time [us].
-      float TimeMean    { kSignalingNaN     }; //!< Mean time of hits [us].
-      float TimeSD      { kSignalingNaN     }; //!< Standard deviation of hit times [us].
-      float FirstTime   { kSignalingNaN     }; //!< Time of first hit [us].
-      float TotalPE     { kSignalingNaN     }; //!< Total number of PE across all PMTs.
-      float FastToTotal { kSignalingNaN     }; //!< Fast to total light ratio.
-      float YCenter     { kSignalingNaN     }; //!< Geometric center in y [cm].
-      float YWidth      { kSignalingNaN     }; //!< Geometric width in y [cm].
-      float ZCenter     { kSignalingNaN     }; //!< Geometric center in z [cm].
-      float ZWidth      { kSignalingNaN     }; //!< Geometric width in z [cm].
-      float XCenter     { kSignalingNaN     }; //!< Geometric center in x [cm].
-      float XWidth      { kSignalingNaN     }; //!< Geometric width in x [cm].
-      int   Cryo        { kUninitializedInt }; //!< 0 for SBND/ICARUS East, 1 for ICARUS West; NOT IN THE RECOB
-      int   FirstPMT    { kUninitializedInt }; //!< Channel number of first hit
+    bool  onbeamtime       { false                        }; //!< Is this in time with beam?
+    int   cryo             { kUninitializedInt            }; //!< 0 for SBND/ICARUS East, 1 for ICARUS West.
+    int   firstpmt         { kUninitializedInt            }; //!< Channel number of first hit
+    float time             { kSignalingNaN                }; //!< Time on trigger time scale [us].
+    float timewidth        { kSignalingNaN                }; //!< Width of the flash in time [us].
+    float timemean         { kSignalingNaN                }; //!< Mean time of hits [us].
+    float timesd           { kSignalingNaN                }; //!< Standard deviation of hit times [us].
+    float firsttime        { kSignalingNaN                }; //!< Time of first hit [us].
+    float totalpe          { kSignalingNaN                }; //!< Total number of PE across all PMTs.
+    float fasttototal      { kSignalingNaN                }; //!< Fast to total light ratio.
+    float peperwall[2] { kSignalingNaN, kSignalingNaN };
 
-      std::vector<float> PEs;                  //!< Number of PE on each PMT (180 entries).
-      std::vector<float> PEsPerWall;           //!< Number of PE on each wall (2 entries); NOT IN THE RECOB
+    SRVector3D center;                                       //!< Geometric center in <x,y,z> [cm].
+    SRVector3D width;                                        //!< Geometric width in <x,y,z> [cm].
 
-      void setDefault();
+    void setDefault();
 
-    };
+  };
 
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -6,6 +6,8 @@
 #ifndef SROPFLASH_H
 #define SROPFLASH_H
 
+#include "sbnanaobj/StandardRecord/SRConstants.h"
+#include <climits>
 
 namespace caf
 {
@@ -13,41 +15,25 @@ namespace caf
   class SROpFlash
     {
     public:
-
       SROpFlash();
 
-      virtual ~SROpFlash() {}
-//NOTE: They all have this. Not sure what exactly this does, but it seems necessary.
-
-      double Time; //Time on trigger time scale [us].
-      double Timewidth; //Width of the flash in time [us].
-      double AbsTime; //Time by PMT readout clock.
-
-      double PE; //Number of PE on a give PMT.
-//NOTE: Might not need this? Doesn't make sense to store each entry separately given that we have the vector form.
-      std::vector<double> PEs; //Number of PE on each PMT.
-      double TotalPE; //Total number of PE across all PMTs.
-      double FastToTotal; //Fast to total light ratio.
-
-      bool OnBeamTime; //Is this in time with beam?
-//NOTE: Changed from int to bool. I have a feeling this int was 0/1.
-
-      bool hasXCenter; //Is the estimated center on x direction is available?
-//NOTE: This one's weird. Do we need this? Do some flashes not have X centers?
-      double XCenter; //Geometric center in x [cm].
-      double XWidth; //Geometric width in x [cm].
-      double YCenter; //Geometric center in y [cm].
-      double YWidth; //Geometric width in y [cm].
-      double ZCenter; //Geometric center in z [cm].
-      double ZWidth; //Geometric width in z [cm].
-
-//NOTE: Dropping frame stuff (uBooNE) and wire centers/widths
-
-      std::vector<double> PE_per_wall; //Backhouse's suggestion
-      int cryo; //0 for SBND/ICARUS East, 1 for ICARUS West
-//NOTE: New additions
+      bool  OnBeamTime  { false             }; //!< Is this in time with beam?
+      float Time        { kSignalingNaN     }; //!< Time on trigger time scale [us].
+      float Timewidth   { kSignalingNaN     }; //!< Width of the flash in time [us].
+      float TotalPE     { kSignalingNaN     }; //!< Total number of PE across all PMTs.
+      float FastToTotal { kSignalingNaN     }; //!< Fast to total light ratio.
+      float YCenter     { kSignalingNaN     }; //!< Geometric center in y [cm].
+      float YWidth      { kSignalingNaN     }; //!< Geometric width in y [cm].
+      float ZCenter     { kSignalingNaN     }; //!< Geometric center in z [cm].
+      float ZWidth      { kSignalingNaN     }; //!< Geometric width in z [cm].
+      float XCenter     { kSignalingNaN     }; //!< Geometric center in x [cm].
+      float XWidth      { kSignalingNaN     }; //!< Geometric width in x [cm].
+      int   Cryo        { kUninitializedInt }; //!< 0 for SBND/ICARUS East, 1 for ICARUS West; NOT IN THE RECOB
+      std::vector<float> PEs;                  //!< Number of PE on each PMT (180 entries).
+      std::vector<float> PEsPerWall;           //!< Number of PE on each wall (2 entries); NOT IN THE RECOB
 
       void setDefault();
+
     };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -21,6 +21,9 @@ namespace caf
       bool  OnBeamTime  { false             }; //!< Is this in time with beam?
       float Time        { kSignalingNaN     }; //!< Time on trigger time scale [us].
       float TimeWidth   { kSignalingNaN     }; //!< Width of the flash in time [us].
+      float TimeMean    { kSignalingNaN     }; //!< Mean time of hits [us].
+      float TimeSD      { kSignalingNaN     }; //!< Standard deviation of hit times [us].
+      float FirstTime   { kSignalingNaN     }; //!< Time of first hit [us].
       float TotalPE     { kSignalingNaN     }; //!< Total number of PE across all PMTs.
       float FastToTotal { kSignalingNaN     }; //!< Fast to total light ratio.
       float YCenter     { kSignalingNaN     }; //!< Geometric center in y [cm].
@@ -30,6 +33,8 @@ namespace caf
       float XCenter     { kSignalingNaN     }; //!< Geometric center in x [cm].
       float XWidth      { kSignalingNaN     }; //!< Geometric width in x [cm].
       int   Cryo        { kUninitializedInt }; //!< 0 for SBND/ICARUS East, 1 for ICARUS West; NOT IN THE RECOB
+      int   FirstPMT    { kUninitializedInt }; //!< Channel number of first hit
+
       std::vector<float> PEs;                  //!< Number of PE on each PMT (180 entries).
       std::vector<float> PEsPerWall;           //!< Number of PE on each wall (2 entries); NOT IN THE RECOB
 

--- a/sbnanaobj/StandardRecord/StandardRecord.h
+++ b/sbnanaobj/StandardRecord/StandardRecord.h
@@ -14,6 +14,8 @@
 #include "sbnanaobj/StandardRecord/SRSliceRecoBranch.h"
 #include "sbnanaobj/StandardRecord/SRTruthBranch.h"
 #include "sbnanaobj/StandardRecord/SRFakeReco.h"
+#include "sbnanaobj/StandardRecord/SROpFlash.h"
+
 
 /// Common Analysis Files
 namespace caf
@@ -44,7 +46,8 @@ namespace caf
     std::vector<SRCRTHit>       crt_hits; ///< CRT hits in event
     int                        ncrt_tracks; ///< Number of CRT tracks in event
     std::vector<SRCRTTrack>     crt_tracks; ///< CRT tracks in event
-
+    int                        n_flashes; ///< Number of OpFlashes in spill
+    std::vector<SROpFlash>      flash; ///< List of OpFlashes in spill
 
     bool pass_flashtrig;     ///< Whether this Record passed the Flash Trigger requirement
 

--- a/sbnanaobj/StandardRecord/StandardRecord.h
+++ b/sbnanaobj/StandardRecord/StandardRecord.h
@@ -46,8 +46,8 @@ namespace caf
     std::vector<SRCRTHit>       crt_hits; ///< CRT hits in event
     int                        ncrt_tracks; ///< Number of CRT tracks in event
     std::vector<SRCRTTrack>     crt_tracks; ///< CRT tracks in event
-    int                        n_flashes; ///< Number of OpFlashes in spill
-    std::vector<SROpFlash>      flash; ///< List of OpFlashes in spill
+    int                        nopflashes; ///< Number of OpFlashes in spill
+    std::vector<SROpFlash>      opflashes; ///< List of OpFlashes in spill
 
     bool pass_flashtrig;     ///< Whether this Record passed the Flash Trigger requirement
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -275,6 +275,10 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
+  <class name="caf::SROpFlash" ClassVersion="10">
+   <version ClassVersion="10" checksum="2672302824"/>
+  </class>
+
   <enum name="caf::Det_t" ClassVersion="10"/>
   <enum name="caf::Plane_t" ClassVersion="10"/>
   <enum name="caf::Wall_t" ClassVersion="10"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -5,7 +5,8 @@
 <!-- art::Wrappers for these products are defined in CAFMaker -->
 
 <lcgdict>
-  <class name="caf::StandardRecord" ClassVersion="10">
+  <class name="caf::StandardRecord" ClassVersion="11">
+   <version ClassVersion="11" checksum="483883398"/>
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
@@ -275,7 +276,8 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
-  <class name="caf::SROpFlash" ClassVersion="10">
+  <class name="caf::SROpFlash" ClassVersion="11">
+   <version ClassVersion="11" checksum="2756572285"/>
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 


### PR DESCRIPTION
Introduce Standard Record flash object so that they can be stored at the CAF stage. See pull requests in sbncode (https://github.com/SBNSoftware/sbncode/pull/273) and icaruscode (https://github.com/SBNSoftware/icaruscode/pull/409) as well. 