### PR TITLE
Added vector of SROpFlash to SR dictionaries

### DIFF
--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -281,7 +281,8 @@
    <version ClassVersion="11" checksum="2756572285"/>
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
-
+  <class name="std::vector<caf::SROpFlash>" />
+  
   <enum name="caf::Det_t" ClassVersion="10"/>
   <enum name="caf::Plane_t" ClassVersion="10"/>
   <enum name="caf::Wall_t" ClassVersion="10"/>


### PR DESCRIPTION
The dictionary for `std::vector<caf::SROpFlash>` is missing.
This has not prevented ROOT for doing the right thing, but I have found an occasion where the job would break with the related complaint, even if the issue ended up being unrelated.
To avoid misleading errors, I am asking for this dictionary to be added.