### PR TITLE
Addition of trigger information in CAF files adding time within beam gate for data events

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -29,6 +29,7 @@ namespace caf
   // blind(false),
   nbnbinfo(0),
   nnumiinfo(0),
+  ntriggerinfo(0),
   husk(false)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -8,6 +8,7 @@
 #include "sbnanaobj/StandardRecord/SREnums.h"
 #include "sbnanaobj/StandardRecord/SRBNBInfo.h"
 #include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
+#include "sbnanaobj/StandardRecord/SRTrigger.h"
 
 #include <vector>
 
@@ -41,6 +42,8 @@ namespace caf
       std::vector<caf::SRBNBInfo> bnbinfo; ///< storing beam information per subrun
       size_t                       nnumiinfo; ///< Number of NuMIInfo objects
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
+      size_t         ntriggerinfo; ///< Number of Trigger objects
+      std::vector<caf::SRTrigger> triggerinfo; ///< storing trigger information per event
 
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/SRTrigger.cxx
+++ b/sbnanaobj/StandardRecord/SRTrigger.cxx
@@ -1,0 +1,17 @@
+#include "sbnanaobj/StandardRecord/SRTrigger.h"
+ 
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+  SRTrigger::SRTrigger():
+    global_trigger_time(UINT_MAX),
+    beam_gate_time_abs(UINT_MAX),
+    trigger_within_gate(INT_MAX),
+    beam_gate_det_time(std::numeric_limits<double>::signaling_NaN()),
+    global_trigger_det_time(std::numeric_limits<double>::signaling_NaN())
+  {}
+    
+
+}

--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -9,11 +9,11 @@ namespace caf
   {
   public:
     SRTrigger();
-    u_int64_t global_trigger_time;
-    u_int64_t beam_gate_time_abs;
-    int64_t trigger_within_gate;
-    double beam_gate_det_time;
-    double global_trigger_det_time;
+    u_int64_t global_trigger_time; ///< Time of trigger in UTC [ns]
+    u_int64_t beam_gate_time_abs; ///< Time of beam gate opening in UTC [ns]
+    int64_t trigger_within_gate; ///< Time from  beam gate to the trigger [ns]
+    double beam_gate_det_time; ///< Beam gate time on detector time scale [us]
+    double global_trigger_det_time; ///< Trigger time on detector time scale [us]
     
   };
 }

--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -1,0 +1,21 @@
+#ifndef SRTRIGGER_h
+#define SRTRIGGER_h
+
+#include <cstdlib>
+
+namespace caf
+{
+  class SRTrigger
+  {
+  public:
+    SRTrigger();
+    u_int64_t global_trigger_time;
+    u_int64_t beam_gate_time_abs;
+    int64_t trigger_within_gate;
+    double beam_gate_det_time;
+    double global_trigger_det_time;
+    
+  };
+}
+
+#endif

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -234,9 +234,8 @@
    <version ClassVersion="10" checksum="1010873394"/>
   </class>
 
-  <class name="caf::SRTrigger" ClassVersion="11">
-   <version ClassVersion="11" checksum="3388549490"/>
-   <version ClassVersion="10" checksum="3162219101"/>
+  <class name="caf::SRTrigger" ClassVersion="10">
+   <version ClassVersion="10" checksum="3388549490"/>
   </class>
 
   <!--<class name="caf::SRLorentzVector" /> -->

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -10,7 +10,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="15">
+  <class name="caf::SRHeader" ClassVersion="16">
+   <version ClassVersion="16" checksum="2130480854"/>
    <version ClassVersion="15" checksum="2023063203"/>
    <version ClassVersion="14" checksum="381900980"/>
    <version ClassVersion="13" checksum="2553933268"/>
@@ -233,6 +234,11 @@
    <version ClassVersion="10" checksum="1010873394"/>
   </class>
 
+  <class name="caf::SRTrigger" ClassVersion="11">
+   <version ClassVersion="11" checksum="3388549490"/>
+   <version ClassVersion="10" checksum="3162219101"/>
+  </class>
+
   <!--<class name="caf::SRLorentzVector" /> -->
 
   <class name="std::vector<caf::SRSlice>" />
@@ -257,6 +263,7 @@
   <class name="std::vector<caf::SRBNBInfo>" />
   <class name="std::vector<caf::SRNuMIInfo>" />
   <class name="std::vector<caf::SRCRUMBSResult>" />
+  <class name="std::vector<caf::SRTrigger>" />
 
   <class name="caf::SRCRTHit" ClassVersion="11">
    <version ClassVersion="11" checksum="3268314487"/>


### PR DESCRIPTION
Adding trigger information in the header of the StandardRecord in order to hold the trigger information for data events and compute the time within the beam gate for data events.

Tested on ICARUS data from raw -> CAF stage and successfully computed the time within the beam gate for the data. 

Depends on equivalent PRs in icaruscode, sbncode, and sbnobj