### PR TITLE
CRUMBS Multi Signal

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -39,6 +39,11 @@ namespace caf {
 
   SRCRUMBSResult::SRCRUMBSResult()
     : score(std::numeric_limits<float>::signaling_NaN())
+    , ccnumuscore(std::numeric_limits<float>::signaling_NaN())
+    , ccnuescore(std::numeric_limits<float>::signaling_NaN())
+    , ncscore(std::numeric_limits<float>::signaling_NaN())
+    , bestscore(std::numeric_limits<float>::signaling_NaN())
+    , bestid(std::numeric_limits<int>::max())
     , tpc()
     , pds()
     , crt()

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -55,7 +55,12 @@ namespace caf {
     ~SRCRUMBSResult() {}
 
     float score;                         //!< CRUMBS result
-  
+    float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
+    float ccnuescore;                    //!< CRUMBS result, for CCNuE signal
+    float ncscore;                       //!< CRUMBS result, for NC signal
+    float bestscore;                     //!< Best score from the three signal-specific versions
+    int   bestid;                        //!< ID corresponding to the bestscore, 14 for CCNuMu, 12 for CCNuE, 1 for NC
+
     SRCRUMBSTPCVars tpc;                 //!< TPC input variables
     SRCRUMBSPDSVars pds;                 //!< PDS input variables
     SRCRUMBSCRTVars crt;                 //!< CRT input variables

--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.h
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.h
@@ -54,7 +54,7 @@ namespace caf {
     SRCRUMBSResult();
     ~SRCRUMBSResult() {}
 
-    float score;                         //!< CRUMBS result
+    float score;                         //!< CRUMBS result, for inclusive neutrino signal
     float ccnumuscore;                   //!< CRUMBS result, for CCNuMu signal
     float ccnuescore;                    //!< CRUMBS result, for CCNuE signal
     float ncscore;                       //!< CRUMBS result, for NC signal

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -228,7 +228,8 @@
    <version ClassVersion="10" checksum="3796231674"/>
   </class>
 
-  <class name="caf::SRCRUMBSResult" ClassVersion="10">
+  <class name="caf::SRCRUMBSResult" ClassVersion="11">
+   <version ClassVersion="11" checksum="2106876613"/>
    <version ClassVersion="10" checksum="783958853"/>
   </class>
 


### PR DESCRIPTION
Contains the required updates to `SRCRUMBSResult` in order to store separate signal specific versions of the CRUMBS score.