### PR TITLE
Add new time_beam variable to SRFlashMatch

### DIFF
--- a/sbnanaobj/StandardRecord/SRFlashMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.cxx
@@ -13,6 +13,7 @@ namespace caf
   SRFlashMatch::SRFlashMatch():
     present(false),
     time(std::numeric_limits<float>::signaling_NaN()),
+    time_beam(std::numeric_limits<float>::signaling_NaN()),
     chargeQ(std::numeric_limits<float>::signaling_NaN()),
     chargeCenter(SRVector3D()),
     lightPE(std::numeric_limits<float>::signaling_NaN()),
@@ -30,6 +31,7 @@ namespace caf
   {
     present    = false;
     time       = -5.0;
+    time_beam  = -5.0;
     chargeQ    = -5.0;
     lightPE    = -5.0;
     score      = -5.0;

--- a/sbnanaobj/StandardRecord/SRFlashMatch.h
+++ b/sbnanaobj/StandardRecord/SRFlashMatch.h
@@ -19,7 +19,8 @@ namespace caf
       virtual ~SRFlashMatch();
 
       bool  present;             //!< whether there's a match
-      float time;                //!< time of flash
+      float time;                //!< time of flash (NOTE: currently different in MC and data) 
+      float time_beam;           //!< time of flash w.r.t beam spill (same in MC and data)
       float chargeQ;             //!< charge in slc
       SRVector3D chargeCenter;   //!< Weighted center position [cm]
       float lightPE;             //!< photo-electrons on simple flash

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -55,7 +55,8 @@
    <version ClassVersion="11" checksum="3227898381"/>
   </class>
 
-  <class name="caf::SRFlashMatch" ClassVersion="11">
+  <class name="caf::SRFlashMatch" ClassVersion="12">
+   <version ClassVersion="12" checksum="479866321"/>
    <version ClassVersion="11" checksum="1429601394"/>
   </class>
 


### PR DESCRIPTION
Add new time variable to SRFlashMatch which is the same in data and MC. This will always be time relative to the beam spill, while the existing fmatch.time variable is time relative to the beam spill in MC, but time relative to the trigger in data.

The trigger information added recently is technically sufficient, but it's in SRHeader which means we need to look at it spill by spill in CAFAna. It is easier to use for selection in CAFAna if everything is defined for slices instead of just for spills. 

Making a new variable instead of changing the behavior of the old one in case anyone depends on the old behavior. Also, I added a note to the comment for the existing time value warning that it is defined differently in MC and data. I'm open to suggestions for a different name for this new variable, but time_beam is what I'm using for now.