### PR TITLE
add isblind flag to header

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -19,6 +19,7 @@ namespace caf
   evt(0),
   subevt(0),
   ismc(false),
+  isblind(false),
   fno(0),
   ngenevt(0),
   pot(0.),

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -28,6 +28,7 @@ namespace caf
       unsigned int   evt;       ///< ART event number, indexes trigger windows.
       unsigned short subevt;    ///< slice number within spill
       bool           ismc;      ///< data or MC?  True if MC
+      bool           isblind;   ///< is this a blinded or prescaled file? true if so
       unsigned int   fno;       ///< Index of file processed by CAFMaker
       unsigned int   ngenevt;   ///< Number of events generated in input file associated with this record (before any filters)
       float          pot;       ///< POT of the subrun associated with this record

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -10,7 +10,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="16">
+  <class name="caf::SRHeader" ClassVersion="17">
+   <version ClassVersion="17" checksum="2390355049"/>
    <version ClassVersion="16" checksum="2130480854"/>
    <version ClassVersion="15" checksum="2023063203"/>
    <version ClassVersion="14" checksum="381900980"/>


### PR DESCRIPTION
All in the comment - add a flag to the header to tell if this is a blinded or prescaled file - will be used to soften the POT matching requirement in CAFAna