### PR TITLE
Adding offbeam gate counting in CAFs

### DIFF
--- a/sbnanaobj/StandardRecord/SREXTInfo.cxx
+++ b/sbnanaobj/StandardRecord/SREXTInfo.cxx
@@ -1,0 +1,15 @@
+#include "sbnanaobj/StandardRecord/SREXTInfo.h"
+
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+  SREXTInfo::SREXTInfo():
+    gates_since_last_trigger(std::numeric_limits<unsigned int>::max()),
+    isBNBOffBeam(false),
+    isNuMIOffBeam(false),
+    isMajority(false),
+    isMinBias(false)
+  {}
+}

--- a/sbnanaobj/StandardRecord/SREXTInfo.h
+++ b/sbnanaobj/StandardRecord/SREXTInfo.h
@@ -1,0 +1,18 @@
+#ifndef SREXTInfo_h
+#define SREXTInfo_h
+
+namespace caf
+{
+  class SREXTInfo
+  {
+  public:
+    SREXTInfo();
+    unsigned int gates_since_last_trigger;
+    bool isBNBOffBeam;
+    bool isNuMIOffBeam;
+    bool isMajority;
+    bool isMinBias;
+  };
+}
+
+#endif

--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -29,6 +29,7 @@ namespace caf
   // blind(false),
   nbnbinfo(0),
   nnumiinfo(0),
+  nextinfo(0),
   husk(false)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -8,6 +8,7 @@
 #include "sbnanaobj/StandardRecord/SREnums.h"
 #include "sbnanaobj/StandardRecord/SRBNBInfo.h"
 #include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
+#include "sbnanaobj/StandardRecord/SREXTInfo.h"
 
 #include <vector>
 
@@ -30,6 +31,7 @@ namespace caf
       unsigned int   fno;       ///< Index of file processed by CAFMaker
       unsigned int   ngenevt;   ///< Number of events generated in input file associated with this record (before any filters)
       float          pot;       ///< POT of the subrun associated with this record
+      float          extcount;
       MCType_t       mctype;    ///< Type of Monte Carlo used to generate this record
       Det_t          det;       ///< Detector, SBND=1 ICARUS=2
       bool           first_in_subrun; ///< Whether this event is the first in the subrun
@@ -41,6 +43,8 @@ namespace caf
       std::vector<caf::SRBNBInfo> bnbinfo; ///< storing beam information per subrun
       size_t                       nnumiinfo; ///< Number of NuMIInfo objects
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
+      size_t         nextinfo;
+      std::vector<caf::SREXTInfo> extinfo;
 
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -10,7 +10,9 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="15">
+  <class name="caf::SRHeader" ClassVersion="17">
+   <version ClassVersion="17" checksum="2337090307"/>
+   <version ClassVersion="16" checksum="456049177"/>
    <version ClassVersion="15" checksum="2023063203"/>
    <version ClassVersion="14" checksum="381900980"/>
    <version ClassVersion="13" checksum="2553933268"/>
@@ -217,6 +219,10 @@
    <version ClassVersion="10" checksum="3796231674"/>
   </class>
 
+  <class name="caf::SREXTInfo" ClassVersion="10">
+   <version ClassVersion="10" checksum="850665470"/>
+  </class>
+
   <class name="caf::SRCRUMBSResult" ClassVersion="10">
    <version ClassVersion="10" checksum="783958853"/>
   </class>
@@ -256,6 +262,7 @@
   <class name="std::vector<caf::SRStubPlane>" />
   <class name="std::vector<caf::SRBNBInfo>" />
   <class name="std::vector<caf::SRNuMIInfo>" />
+  <class name="std::vector<caf::SREXTInfo>" />
   <class name="std::vector<caf::SRCRUMBSResult>" />
 
   <class name="caf::SRCRTHit" ClassVersion="11">

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -10,7 +10,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="16">
+  <class name="caf::SRHeader" ClassVersion="17">
+   <version ClassVersion="17" checksum="2118058550"/>
    <version ClassVersion="16" checksum="2130480854"/>
    <version ClassVersion="15" checksum="2023063203"/>
    <version ClassVersion="14" checksum="381900980"/>


### PR DESCRIPTION
Added offbeam gate counting in CAFs adding a similar object to what is added for BNB and NuMI spill accounting. Looks at the number of gates for BNB and NuMI offbeam alone for offbeam data which event-by-event is computed as the difference in the number of gates for the previous event.