### PR TITLE
Add missing vector line for SRPFPs to classes def

### DIFF
--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -290,6 +290,7 @@
   <class name="std::vector<caf::SRNuMIInfo>" />
   <class name="std::vector<caf::SRCRUMBSResult>" />
   <class name="std::vector<caf::SRTrigger>" />
+  <class name="std::vector<caf::SRPFP>" />
 
   <class name="caf::SRCRTHit" ClassVersion="11">
    <version ClassVersion="11" checksum="3268314487"/>


### PR DESCRIPTION
Found whilst pursuing a separate issue with the caf stage in the CI. 

We now have [vectors](https://github.com/SBNSoftware/sbnanaobj/blob/develop/sbnanaobj/StandardRecord/SRSliceRecoBranch.h#L22) of SRPFPs, which we didn't used to. This requires a vector line in the classes def file. This seemed to cause _intermittent_ issues when saving / opening caf files.