### PR TITLE
Feature/jsmedley fill barycenter

### DIFF
--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -18,6 +18,8 @@ namespace caf
   void SRSlice::setDefault()
   {
     charge         = -5;
+    charge_center  = SRVector3D(-9999.f, -9999.f, -9999.f);
+    charge_width   = SRVector3D(-9999.f, -9999.f, -9999.f);
   }
 
 

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -18,8 +18,6 @@ namespace caf
   void SRSlice::setDefault()
   {
     charge         = -5;
-    charge_center  = SRVector3D(-9999.f, -9999.f, -9999.f);
-    charge_width   = SRVector3D(-9999.f, -9999.f, -9999.f);
   }
 
 

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -31,8 +31,8 @@ namespace caf
       unsigned producer { UINT_MAX };     ///< Index of the producer that produced this object. 
                                           ///< In ICARUS, this is the same as the cryostat.
       float    charge { kSignalingNaN };  ///< Calorimetric energy
-      SRVector3D charge_center;           ///< Weighted mean of hit positions in XYZ, COLLECTION PLANE ONLY [cm]
-      SRVector3D charge_width;            ///< Weighted standard deviation of hit positions in XYZ, COLLECTION PLANE ONLY [cm]
+      SRVector3D charge_center;           ///< Weighted mean of hit positions in XYZ [cm]
+      SRVector3D charge_width;            ///< Weighted standard deviation of hit positions in XYZ [cm]
       SRVector3D vertex;                  ///< Candidate neutrino vertex in local detector coordinates [cm]
 
       SRTrueInteraction truth; //!< Truth information on the slice

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -31,6 +31,8 @@ namespace caf
       unsigned producer { UINT_MAX };     ///< Index of the producer that produced this object. 
                                           ///< In ICARUS, this is the same as the cryostat.
       float    charge { kSignalingNaN };  ///< Calorimetric energy
+      SRVector3D charge_center;           ///< Weighted mean of hit positions in XYZ, COLLECTION PLANE ONLY [cm]
+      SRVector3D charge_width;            ///< Weighted standard deviation of hit positions in XYZ, COLLECTION PLANE ONLY [cm]
       SRVector3D vertex;                  ///< Candidate neutrino vertex in local detector coordinates [cm]
 
       SRTrueInteraction truth; //!< Truth information on the slice

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -55,7 +55,8 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="14">
+  <class name="caf::SRSlice" ClassVersion="15">
+   <version ClassVersion="15" checksum="2724994355"/>
    <version ClassVersion="14" checksum="740791578"/>
    <version ClassVersion="13" checksum="1378484383"/>
    <version ClassVersion="12" checksum="3783103871"/>


### PR DESCRIPTION
This PR would introduce to each slice in the CAF the charge weighted mean position `charge_center` and standard standard deviation `charge_width` of 3D SpacePoints. The primary use case for this is studies on barycenter flash matching, which have so far opted to use CAFs produced with the option `FillHits: true`. This would allow these studies to continue without being limited to CAFs inflated with TPC hits. 

Tied to sbncode PR https://github.com/SBNSoftware/sbncode/pull/348