### PR TITLE
add CRTPMT Matching variables to the StandardRecord

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTPMTMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTPMTMatch.cxx
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRCRTPMTMatch.cxx
+////////////////////////////////////////////////////////////////////////
+
+#include "sbnanaobj/StandardRecord/SRCRTPMTMatch.h"
+#include <climits>
+
+namespace caf
+{
+  SRMatchedCRT::SRMatchedCRT():
+    PMTTimeDiff(std::numeric_limits<double>::lowest()),
+    time(std::numeric_limits<double>::lowest()),
+    sys(-1),
+    region(-1)
+  {}
+
+
+  SRCRTPMTMatch::SRCRTPMTMatch():
+    flashID(std::numeric_limits<int>::min()),
+    flashTime_us(std::numeric_limits<double>::signaling_NaN())
+    
+
+    //flashGateTime_ns(std::numeric_limits<double>::signaling_NaN())
+    //flashInGate(false),
+    //flashInBeam(false),
+    //flashClassification()
+    //void SRCRTPMTMatch::setDefault(){flashPosition = .. }
+  {}
+
+  /*SRMatchedCRT::SRMatchedCRT():
+    PMTTimeDiff(std::numeric_limits<double>::lowest()),
+    time(std::numeric_limits<double>::lowest()),
+    sys(-1),
+    region(-1)
+    {}*/
+
+} // end namespace caf 
+////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTPMTMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTPMTMatch.h
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRCRTPMTMatch.h
+////////////////////////////////////////////////////////////////////////
+#ifndef SRCRTPMTMATCH_H
+#define SRCRTPMTMATCH_H
+
+#include "sbnanaobj/StandardRecord/SRVector3D.h"
+
+namespace caf
+{
+  /*  /// Type of match between a TPC object (e.g. PMT flash) and CRT system.
+  enum class MatchType {
+    noMatch           = 0, ///< No CRT match.
+      enTop             = 1, ///< Matched with Top CRT hit before optical flash.
+      enSide            = 2, ///< Matched with Side CRT hit before optical flash.
+      enTop_exSide      = 3, ///< Matched with one Top CRT hit before the optical flash and matched with one Side CRT hit after the optical flash.
+      exTop             = 4, ///< Matched with a Top CRT after the optical flash.
+      exSide            = 5, ///< Matched with a Side CRT after the optical flash.
+      enTop_mult        = 6, ///< Matched with multiple Top CRT hits before the optical flash.
+      enTop_exSide_mult = 7, ///< Matched with multiple Top CRT hits before the optical flash and more then 1 side CRT hits after the optical flash.
+      enBottom          = 8, ///< Matched with bottom CRT hit before the optical flash.
+      exBottom          = 10, ///< Matched with Bottom CRT hit after the optical flash.
+      enTop_exBottom    = 11, ///< Matched with one Top CRT hit before the optical flash and
+      enSide_exBottom   = 12, ///< Matched with one Side CRT hit before the optical flash and matched with one Bottom CRT hit after the optical flash.
+      exTop_enBottom    = 13, ///< Matched with one Bottom CRT hit before the optical flash and matched with one Top CRT hit after the optical flash.
+      exSide_enBottom   = 14, ///< Matched with one Bottom CRT hit before the optical flash and matched with one Side CRT hit after the optical flash.
+      others            = 9  ///< All the other cases.
+
+      };*/
+
+
+
+  class SRMatchedCRT 
+  {
+    public: 
+      SRMatchedCRT();
+      ~SRMatchedCRT() {}
+      //struct MatchedCRT {
+      /// Special value to indicate no information on the hit location.
+      //static constexpr int NoLocation = -1;
+      SRVector3D position;           ///< Hit location [cm]
+      double PMTTimeDiff;/* = NoTime;*/     ///< CRT hit time minus PMT flash time [us]
+      double time;/*        = NoTime;*/     ///< CRT hit time [us]
+      int sys;/*            = NoLocation;*/ ///< CRT subdetector the hit fell into.
+      int region;/*         = NoLocation;*/ ///< Region the matched CRT hit fell into.
+  };
+
+  class SRCRTPMTMatch
+    {
+    public:
+      SRCRTPMTMatch();
+      virtual ~SRCRTPMTMatch() {}
+      int flashID; ///< ID of the optical flash. 
+      double flashTime_us; ///< Time of the optical flash w.r.t. the global trigger in us.
+      
+      double flashGateTime; ///< Time of the optical flash w.r.t. the beam gate opening in ns.
+      double       firstOpHitPeakTime; ///< Time of the first optical hit peak time w.r.t. the global trigger 
+      double       firstOpHitStartTime;  ///< Time of the first optical hit start time w.r.t. the global trigger [us]
+      bool flashInGate; ///< Flash within gate or not.
+      bool flashInBeam; ///< Flash within the beam window of the gate or not.
+      double flashPE; ///< Total reconstructed light in the flash [photoelectrons]
+      SRVector3D flashPosition; ///< Flash barycenter coordinates evaluated using ADCs as weights.
+      double       flashYWidth; ///< Flash spread along Y. 
+      double       flashZWidth; ///< Flash spread along Z. 
+      int flashClassification;///< Classication of the optical flash.
+      std::vector<SRMatchedCRT> matchedCRTHits;     ///< Matched CRT Hits with the optical flash.
+      
+      //enum matchType ......;
+      //int flashClassification;///< Classication of the optical flash.*/
+      // std vector of matched CRT Hits 
+      //void setDefault();
+    };
+} // end namespace 
+#endif // SRCRTPMTMATCH_H
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/StandardRecord.h
+++ b/sbnanaobj/StandardRecord/StandardRecord.h
@@ -10,12 +10,12 @@
 #include "sbnanaobj/StandardRecord/SRCRTHit.h"
 #include "sbnanaobj/StandardRecord/SRCRTTrack.h"
 #include "sbnanaobj/StandardRecord/SRHeader.h"
+#include "sbnanaobj/StandardRecord/SRCRTPMTMatch.h"
 #include "sbnanaobj/StandardRecord/SRSlice.h"
 #include "sbnanaobj/StandardRecord/SRSliceRecoBranch.h"
 #include "sbnanaobj/StandardRecord/SRTruthBranch.h"
 #include "sbnanaobj/StandardRecord/SRFakeReco.h"
 #include "sbnanaobj/StandardRecord/SROpFlash.h"
-
 
 /// Common Analysis Files
 namespace caf
@@ -48,7 +48,9 @@ namespace caf
     std::vector<SRCRTTrack>     crt_tracks; ///< CRT tracks in event
     int                        nopflashes; ///< Number of OpFlashes in spill
     std::vector<SROpFlash>      opflashes; ///< List of OpFlashes in spill
-
+    
+    int                        ncrtpmt_matches; ///<Number of CRT-PMT Matches in event 
+    std::vector<SRCRTPMTMatch> crtpmt_matches;  ///< CRT-PMT matches in event 
     bool pass_flashtrig;     ///< Whether this Record passed the Flash Trigger requirement
 
   };

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -5,7 +5,8 @@
 <!-- art::Wrappers for these products are defined in CAFMaker -->
 
 <lcgdict>
-  <class name="caf::StandardRecord" ClassVersion="11">
+  <class name="caf::StandardRecord" ClassVersion="12">
+   <version ClassVersion="12" checksum="3984422068"/>
    <version ClassVersion="11" checksum="483883398"/>
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
@@ -325,7 +326,10 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
   <class name="std::vector<caf::SROpFlash>" />
-  
+  <class name="caf::SRCRTPMTMatch"/>
+  <class name="std::vector<caf::SRCRTPMTMatch>"/>
+  <class name="caf::SRMatchedCRT"/>
+  <class name="std::vector<caf::SRMatchedCRT>"/>
   <enum name="caf::Det_t" ClassVersion="10"/>
   <enum name="caf::Plane_t" ClassVersion="10"/>
   <enum name="caf::Wall_t" ClassVersion="10"/>


### PR DESCRIPTION
This pull request, along with sbncode PR #[353](https://github.com/SBNSoftware/sbncode/pull/353), adds a new variable to the CAFs. This
* adds a `SRCRTPMTMatch` class to the StandardRecord `SRCRTPMTMatch.{cxx,h}`

This PR is dependent on 
* icaurscode PR #[594](https://github.com/SBNSoftware/icaruscode/pull/594) 
* sbnobj PR #[86](https://github.com/SBNSoftware/sbnobj/pull/86)
* sbncode PR #[353](https://github.com/SBNSoftware/sbncode/pull/353)