### PR TITLE
Added source file information to the standard record header

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -11,14 +11,18 @@
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 
 #include <vector>
-#ifndef __castxml_major__
-# include <string>
-#else
+#if defined(__castxml_major__) && !defined(__clang__)
 // This header is processed by CASTXML to extract information for the flat CAF;
 // CASTXML uses Clang 7.0 to parse it, and Clang 7.0 does not understand GCC's
 // <string> header. So we cheat. TO BE REMOVED on CASTXML/pygccxml update:
 // https://github.com/CastXML/CastXML/issues/178
+// In addition, when using CASTXML with Clang, the build seems to include
+// <string> header somewhere else (via <iosfwd.h> in SRHeader.h),
+// so this mock-up definition would conflict with the one in that <string>
+// header: therefore, when using Clang we don't use this trick.
 namespace std { class string {}; }
+#else
+# include <string>
 #endif
 #include <limits> // std::numeric_limits
 

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -13,6 +13,12 @@
 #include <vector>
 #ifndef __castxml_major__
 # include <string>
+#else
+// This header is processed by CASTXML to extract information for the flat CAF;
+// CASTXML uses Clang 7.0 to parse it, and Clang 7.0 does not understand GCC's
+// <string> header. So we cheat. TO BE REMOVED on CASTXML/pygccxml update:
+// https://github.com/CastXML/CastXML/issues/178
+namespace std { class string {}; }
 #endif
 #include <limits> // std::numeric_limits
 
@@ -52,9 +58,7 @@ namespace caf
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
-#ifndef __castxml_major__
       std::string    sourceName; ///< Name of the file or source this event comes from.
-#endif
       unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -11,6 +11,8 @@
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 
 #include <vector>
+#include <string>
+#include <limits> // std::numeric_limits
 
 namespace caf
 {
@@ -18,6 +20,9 @@ namespace caf
   class SRHeader
     {
     public:
+      static constexpr unsigned int NoSourceIndex
+        = std::numeric_limits<unsigned int>::max();
+      
       SRHeader();
       ~SRHeader();
 
@@ -45,6 +50,8 @@ namespace caf
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
+      std::string    sourceName; ///< Name of the file or source this event comes from.
+      unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -11,7 +11,9 @@
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 
 #include <vector>
-#include <string>
+#ifndef __castxml_major__
+# include <string>
+#endif
 #include <limits> // std::numeric_limits
 
 namespace caf
@@ -50,7 +52,9 @@ namespace caf
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
+#ifndef __castxml_major__
       std::string    sourceName; ///< Name of the file or source this event comes from.
+#endif
       unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -10,7 +10,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="18">
+  <class name="caf::SRHeader" ClassVersion="19">
+   <version ClassVersion="19" checksum="1204111507"/>
    <version ClassVersion="18" checksum="1724302139"/>
    <version ClassVersion="17" checksum="2390355049"/>
    <version ClassVersion="16" checksum="2130480854"/>


### PR DESCRIPTION
Added a string and an index representing the name of the source of the event (typically a source file) and an index within that represents how to identify it in that source.

Matter of review by SBN!
Please add reviewer as needed (esp. from SBND).

Sibling request to _fill_ the information: SBNSoftware/sbncode#361