### PR TITLE
Fix checksum in `classes_def.xml` 

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTPMTMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTPMTMatch.h
@@ -34,7 +34,6 @@ namespace caf
   {
     public: 
       SRMatchedCRT();
-      ~SRMatchedCRT() {}
       //struct MatchedCRT {
       /// Special value to indicate no information on the hit location.
       //static constexpr int NoLocation = -1;
@@ -49,7 +48,6 @@ namespace caf
     {
     public:
       SRCRTPMTMatch();
-      virtual ~SRCRTPMTMatch() {}
       int flashID; ///< ID of the optical flash. 
       double flashTime_us; ///< Time of the optical flash w.r.t. the global trigger in us.
       

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -326,9 +326,13 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
   <class name="std::vector<caf::SROpFlash>" />
-  <class name="caf::SRCRTPMTMatch" ClassVersion="10" />
+  <class name="caf::SRCRTPMTMatch" ClassVersion="10" >
+   <version ClassVersion="10" checksum="2059576953"/>
+  </class>
   <class name="std::vector<caf::SRCRTPMTMatch>"/>
-  <class name="caf::SRMatchedCRT" ClassVersion="10" />
+  <class name="caf::SRMatchedCRT" ClassVersion="10" >
+   <version ClassVersion="10" checksum="4053405227"/>
+  </class>
   <class name="std::vector<caf::SRMatchedCRT>"/>
   <enum name="caf::Det_t" ClassVersion="10"/>
   <enum name="caf::Plane_t" ClassVersion="10"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -326,9 +326,9 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
   <class name="std::vector<caf::SROpFlash>" />
-  <class name="caf::SRCRTPMTMatch"/>
+  <class name="caf::SRCRTPMTMatch" ClassVersion="10" />
   <class name="std::vector<caf::SRCRTPMTMatch>"/>
-  <class name="caf::SRMatchedCRT"/>
+  <class name="caf::SRMatchedCRT" ClassVersion="10" />
   <class name="std::vector<caf::SRMatchedCRT>"/>
   <enum name="caf::Det_t" ClassVersion="10"/>
   <enum name="caf::Plane_t" ClassVersion="10"/>


### PR DESCRIPTION
This PR addresses something missed my in [PR#95](https://github.com/SBNSoftware/sbnanaobj/pull/95) that was merged into develop in [v09_21_02](https://github.com/SBNSoftware/sbnanaobj/commit/f977ece2fbe88554e1ed64399645b97d5b797a67). Gianluca suggested to Enable the ROOT schema for the classes defs [ in this review comment](https://github.com/SBNSoftware/sbnanaobj/pull/97#discussion_r1239968104) on a [sbnanaobj#PR97](https://github.com/SBNSoftware/sbnanaobj/pull/97), and which #97 being a duplicate of #95 we should also add these changes here. 
