### PR TITLE
opt0finder objects in cafmaker

### DIFF
--- a/sbnanaobj/StandardRecord/SROpT0Finder.cxx
+++ b/sbnanaobj/StandardRecord/SROpT0Finder.cxx
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SROpT0Finder.cxx
+// \brief   An SROpT0Finder contains matching information between
+//          a slice and the OpT0Finder object
+////////////////////////////////////////////////////////////////////////
+#include "sbnanaobj/StandardRecord/SROpT0Finder.h"
+
+#include <limits>
+#include <climits>
+
+namespace caf
+{
+
+SROpT0Finder::SROpT0Finder():
+    tpc(INT_MIN),     // tpc that the matching was performed in
+    time(std::numeric_limits<float>::signaling_NaN()),    // flash-matched t0  
+    score(std::numeric_limits<float>::signaling_NaN()),   // OpT0 score of the match; is the reciprocal of the LLH score or chi-squared score 
+    measPE(std::numeric_limits<float>::signaling_NaN()),  // total PE of the measured flash 
+    hypoPE(std::numeric_limits<float>::signaling_NaN())   // total PE of the hypothetical flash 
+{}
+
+} // end namespace caf
+////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SROpT0Finder.h
+++ b/sbnanaobj/StandardRecord/SROpT0Finder.h
@@ -9,6 +9,8 @@ namespace caf
   class SROpT0Finder {
   public:
     SROpT0Finder();            //!< Constructor
+    ~SROpT0Finder() {}
+    
     int   tpc;    // tpc that the matching was performed in
     float time;    // flash-matched t0  
     float score;   // OpT0 score of the match; is the reciprocal of the LLH score or chi-squared score 

--- a/sbnanaobj/StandardRecord/SROpT0Finder.h
+++ b/sbnanaobj/StandardRecord/SROpT0Finder.h
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SROpT0Finder.h
+////////////////////////////////////////////////////////////////////////
+#ifndef SROPT0FINDER_H
+#define SROPT0FINDER_H
+
+namespace caf
+{
+  class SROpT0Finder {
+  public:
+    SROpT0Finder();            //!< Constructor
+    int   tpc;    // tpc that the matching was performed in
+    float time;    // flash-matched t0  
+    float score;   // OpT0 score of the match; is the reciprocal of the LLH score or chi-squared score 
+    float measPE;  // total PE of the measured flash 
+    float hypoPE;  // total PE of the shypothetical flash   
+    };
+} // end namespace
+
+#endif 
+//////////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -9,6 +9,7 @@
 #include "sbnanaobj/StandardRecord/SRCRUMBSResult.h"
 #include "sbnanaobj/StandardRecord/SRFakeReco.h"
 #include "sbnanaobj/StandardRecord/SRFlashMatch.h"
+#include "sbnanaobj/StandardRecord/SROpT0Finder.h"
 #include "sbnanaobj/StandardRecord/SRSliceRecoBranch.h"
 #include "sbnanaobj/StandardRecord/SRTrueInteraction.h"
 #include "sbnanaobj/StandardRecord/SRTruthMatch.h"
@@ -42,8 +43,10 @@ namespace caf
       SRFlashMatch fmatch_a; //!< Optical flash-match for this slice of TPC charge
       SRFlashMatch fmatch_b; //!< Optical flash-match for this slice of TPC charge
 
-      SRFakeReco fake_reco;
+      SROpT0Finder opt0;       //!< OpT0Finder (flash-match and Q->L); filled with the **highest OpT0 score** assoc. to the slice 
+      SROpT0Finder opt0_sec;   //!< Secondary OpT0Finder (flash-match and Q->L); filled with the **second highest OpT0 score**  assoc. to the slice 
 
+      SRFakeReco fake_reco;
 
       bool is_clear_cosmic { false };         //!< Whether pandora marks the slice as a "clear" cosmic
       int nu_pdg           { INT_MIN };       //!< PDG assigned to the PFParticle Neutrino

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -71,8 +71,7 @@
    <version ClassVersion="11" checksum="1429601394"/>
   </class>
 
-  <class name="caf::SROpT0Finder">
-  </class>
+  <class name="caf::SROpT0Finder" />
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="13">
    <version ClassVersion="13" checksum="4211357366"/>
@@ -303,6 +302,7 @@
   <class name="std::vector<caf::SRBNBInfo>" />
   <class name="std::vector<caf::SRNuMIInfo>" />
   <class name="std::vector<caf::SRCRUMBSResult>" />
+  <class name="std::vector<caf::SROpT0Finder>" />
   <class name="std::vector<caf::SRTrigger>" />
   <class name="std::vector<caf::SRPFP>" />
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -56,7 +56,9 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="15">
+  <class name="caf::SRSlice" ClassVersion="17">
+   <version ClassVersion="17" checksum="939002953"/>
+   <version ClassVersion="16" checksum="2418184640"/>
    <version ClassVersion="15" checksum="2724994355"/>
    <version ClassVersion="14" checksum="740791578"/>
    <version ClassVersion="13" checksum="1378484383"/>
@@ -67,6 +69,9 @@
   <class name="caf::SRFlashMatch" ClassVersion="12">
    <version ClassVersion="12" checksum="2334957166"/>
    <version ClassVersion="11" checksum="1429601394"/>
+  </class>
+
+  <class name="caf::SROpT0Finder">
   </class>
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="13">


### PR DESCRIPTION
Moving OpT0 variables into the cafs. There are _two_ caf variables created: `slc.opt0` and `slc.opt0_sec`, where the latter is the "secondary" OpT0 object. 

OpT0Finder (in SBND for one-to-many matching) can output more than one match per slice if the slice is split up between two TPCs (matches are TPC specific) or if there are multiple in-time flashes. The default `slc.opt0` is filled with the OpT0 object with the **highest** OpT0 score (best match), and `slc.opt0_sec` is filled with the OpT0 object with the **second highest** OpT0 score. 

For flash-matching, looking at `slc.opt0` would be sufficient. For Q->L charge-likelihood studies, one would likely want information from both TPCs (so look at both `slc.opt0` and `slc.opt0_sec`). 

Accompanying PR in sbncode [#367](https://github.com/SBNSoftware/sbncode/pull/367) and sbnobj [#90](https://github.com/SBNSoftware/sbnobj/pull/90). 