### PR TITLE
Remove the constant from SRHeader object [1/2] [SBN2023A]

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -32,9 +32,15 @@ namespace caf
   class SRHeader
     {
     public:
-      static constexpr unsigned int NoSourceIndex
-        = std::numeric_limits<unsigned int>::max();
-      
+      // --- BEGIN FIXME ---------------------------------------------------
+      // the commit that introduced the following change should be REVERTED,
+      // together with the related commit 9712afa6 of sbncode,
+      // as soon as the branch can be built with SRProxy v. 0.41 or later,
+      // which supports constants in classes.
+      static constexpr unsigned int NoSourceIndex()
+        { return std::numeric_limits<unsigned int>::max(); }
+      // --- END - FIXME ---------------------------------------------------
+
       SRHeader();
       ~SRHeader();
 
@@ -63,7 +69,7 @@ namespace caf
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
-      unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
+      unsigned int   sourceIndex = NoSourceIndex(); ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any


### PR DESCRIPTION
SRProxy prior to 0.41 doesn't support static data in the class.
I am turning the static constant I put into a static function for the time being.

The `develop` branch already uses an updated SRProxy (`v0.42` at this time).
This commit should not survive into the development branch and it must be **reverted** when it lands there.

Also bound to SBNSoftware/sbncode#380 PR (since this is effectively an interface change).