### PR TITLE
Added OpFlashes and XARAPUCA flashes to SimpleFlash

### DIFF
--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -40,20 +40,9 @@ namespace caf
       SRTruthMatch tmatch; //!< Matching information between truth and reco objects
 
       SRFlashMatch fmatch;   //!< PMT Simple flash-match for this slice of TPC charge
-      SRFlashMatch fmatch_a; //!< PMT Simple  flash-match for this slice of TPC charge
-      SRFlashMatch fmatch_b; //!< PMT Simple flash-match for this slice of TPC charge
-
       SRFlashMatch fmatchop;   //!< PMT Simple flash-match for this slice of TPC charge (OpFlash)
-      SRFlashMatch fmatchop_a; //!< PMT Simple  flash-match for this slice of TPC charge (OpFlash)
-      SRFlashMatch fmatchop_b; //!< PMT Simple flash-match for this slice of TPC charge (OpFlash)
-
       SRFlashMatch fmatchara;   //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA, SBND only)
-      SRFlashMatch fmatchara_a; //!< PMT Simple  flash-match for this slice of TPC charge (XARAPUCA, SBND only)
-      SRFlashMatch fmatchara_b; //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA, SBND only)
-
       SRFlashMatch fmatchopara;   //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
-      SRFlashMatch fmatchopara_a; //!< PMT Simple  flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
-      SRFlashMatch fmatchopara_b; //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
 
       SROpT0Finder opt0;       //!< OpT0Finder (flash-match and Q->L); filled with the **highest OpT0 score** assoc. to the slice 
       SROpT0Finder opt0_sec;   //!< Secondary OpT0Finder (flash-match and Q->L); filled with the **second highest OpT0 score**  assoc. to the slice 

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -36,9 +36,21 @@ namespace caf
       SRTrueInteraction truth; //!< Truth information on the slice
       SRTruthMatch tmatch; //!< Matching information between truth and reco objects
 
-      SRFlashMatch fmatch;   //!< Optical flash-match for this slice of TPC charge
-      SRFlashMatch fmatch_a; //!< Optical flash-match for this slice of TPC charge
-      SRFlashMatch fmatch_b; //!< Optical flash-match for this slice of TPC charge
+      SRFlashMatch fmatch;   //!< PMT Simple flash-match for this slice of TPC charge
+      SRFlashMatch fmatch_a; //!< PMT Simple  flash-match for this slice of TPC charge
+      SRFlashMatch fmatch_b; //!< PMT Simple flash-match for this slice of TPC charge
+
+      SRFlashMatch fmatchop;   //!< PMT Simple flash-match for this slice of TPC charge (OpFlash)
+      SRFlashMatch fmatchop_a; //!< PMT Simple  flash-match for this slice of TPC charge (OpFlash)
+      SRFlashMatch fmatchop_b; //!< PMT Simple flash-match for this slice of TPC charge (OpFlash)
+
+      SRFlashMatch fmatchara;   //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA, SBND only)
+      SRFlashMatch fmatchara_a; //!< PMT Simple  flash-match for this slice of TPC charge (XARAPUCA, SBND only)
+      SRFlashMatch fmatchara_b; //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA, SBND only)
+
+      SRFlashMatch fmatchopara;   //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
+      SRFlashMatch fmatchopara_a; //!< PMT Simple  flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
+      SRFlashMatch fmatchopara_b; //!< PMT Simple flash-match for this slice of TPC charge (XARAPUCA OpFlash, SBND only)
 
       SRFakeReco fake_reco;
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -57,7 +57,9 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="17">
+  <class name="caf::SRSlice" ClassVersion="19">
+   <version ClassVersion="19" checksum="3108582545"/>
+   <version ClassVersion="18" checksum="3464825901"/>
    <version ClassVersion="17" checksum="939002953"/>
    <version ClassVersion="16" checksum="2418184640"/>
    <version ClassVersion="15" checksum="2724994355"/>


### PR DESCRIPTION
- Added OpFlashes to SimpleFlash for SBND and ICARUS
- Added XARAPUCA flashes to SimpleFlash for SBND
- - 2/4 flashes/slice in ICARUS/SBND
- - Each slice has seperate training metrics
- SRSlice updated to account for extra slices