### PR TITLE
Use kDefaultRWType for the default ReweightType_t

### DIFF
--- a/sbnanaobj/StandardRecord/SREnums.h
+++ b/sbnanaobj/StandardRecord/SREnums.h
@@ -222,7 +222,7 @@ namespace caf
 
   //==== This should be synchronized to rwtype in sbnobj/Common/SBNEventWeight/EventWeightParameterSet.h
   enum ReweightType_t{
-    kDefault = -1,
+    kDefaultRWType = -1,
     kMultiSim = 0,
     kPMNSigma = 1,
     kFixed = 2,


### PR DESCRIPTION
`kDefault` is too generic and might be mis-used by other enums.