### PR TITLE
New ICARUS training for track vs shower discrimination Pandora BDT

### DIFF
--- a/sbnanaobj/StandardRecord/SRPFOChar.cxx
+++ b/sbnanaobj/StandardRecord/SRPFOChar.cxx
@@ -23,6 +23,9 @@ namespace caf
     pca2ratio = -9999.f;
     pca3ratio = -9999.f;
     vtxdist = -9999.f;
+    halototratio = -9999.f;
+    concentration = -9999.f;
+    conicalness = -9999.f;
   }
 
 

--- a/sbnanaobj/StandardRecord/SRPFOChar.h
+++ b/sbnanaobj/StandardRecord/SRPFOChar.h
@@ -26,6 +26,9 @@ namespace caf
     float pca2ratio     { kSignalingNaN }; // LArThreeDPCAFeatureTool_SecondaryPCARatio feature
     float pca3ratio     { kSignalingNaN }; // LArThreeDPCAFeatureTool_TertiaryPCARatio feature
     float vtxdist       { kSignalingNaN }; // LArThreeDVertexDistanceFeatureTool_VertexDistance feature
+    float halototratio  { kSignalingNaN }; // LArConeChargeFeatureTool_HaloTotalRatio feature
+    float concentration { kSignalingNaN }; // LArConeChargeFeatureTool_Concentration feature
+    float conicalness   { kSignalingNaN }; // LArConeChargeFeatureTool_Conicalness feature
 
     void setDefault();
   };

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -26,7 +26,8 @@
    <version ClassVersion="10" checksum="1379012114"/>
   </class>
 
-  <class name="caf::SRPFOChar" ClassVersion="10" >
+  <class name="caf::SRPFOChar" ClassVersion="11" >
+   <version ClassVersion="11" checksum="1471728789"/>
    <version ClassVersion="10" checksum="1756876186"/>
   </class>
 


### PR DESCRIPTION
This PR contains the new variables for the new training for track vs shower discrimination in Pandora automatic reconstruction (i.e. LArBdtPfoCharacterisation) based on ICARUS bnb simulations (icaruscode v09_72_01) and including three new BDT variables.

This PR should also include changes to branches with the same name of the following repositories:

feature/acampani_sdellepi_new_BdtPfoCharacterisation in icaruscode (PR#656)
feature/acampani_sdellepi_new_BdtPfoCharacterisation in sbncode
the new BDT training .xml file in icarus_data/icarus_data/PandoraMVAs/PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml