### PR TITLE
Add offbeam gate count to SRHeader

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -29,7 +29,9 @@ namespace caf
   cluster(-1),
   // blind(false),
   nbnbinfo(0),
+  noffbeambnb(0.0),
   nnumiinfo(0),
+  noffbeamnumi(0.0),
   husk(false)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -47,9 +47,11 @@ namespace caf
       size_t                      nbnbinfo; ///< Number of BNBInfo objects
       std::vector<caf::SRBNBInfo> bnbinfo; ///< storing beam information per subrun
       caf::SRBNBInfo              spillbnbinfo; ///< storing beam information for given event's spill
+      double noffbeambnb; ///< Number of offbeam BNB gates
       size_t                       nnumiinfo; ///< Number of NuMIInfo objects
       std::vector<caf::SRNuMIInfo> numiinfo; ///< storing beam information per subrun
       caf::SRNuMIInfo              spillnumiinfo; ///< storing beam information for given event's spill
+      double noffbeamnumi; ///< Number of offbeam NuMI gates
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
       std::string    sourceName; ///< Name of the file or source this event comes from.

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -12,7 +12,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="20">
+  <class name="caf::SRHeader" ClassVersion="21">
+   <version ClassVersion="21" checksum="861604402"/>
    <version ClassVersion="20" checksum="185218613"/>
    <version ClassVersion="19" checksum="1204111507"/>
    <version ClassVersion="18" checksum="1724302139"/>


### PR DESCRIPTION
Add variables to SRHeader to save offbeam gate count. These should be doubles due to the correction made to account for minbias events.