### PR TITLE
Adding GENIE Tree index to SRTrueInteraction [release/SBN2023A_NuMI_2]

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -71,6 +71,7 @@ namespace caf
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
+      size_t         sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
       unsigned int   sourceIndex = NoSourceIndex(); ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -71,7 +71,7 @@ namespace caf
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
-      size_t         sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
+      unsigned int   sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
       unsigned int   sourceIndex = NoSourceIndex(); ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -10,6 +10,7 @@
 #include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 
+#include <cstdint>
 #include <vector>
 #if defined(__castxml_major__) && !defined(__clang__)
 // This header is processed by CASTXML to extract information for the flat CAF;
@@ -71,7 +72,7 @@ namespace caf
       caf::SRTrigger triggerinfo; ///< storing trigger information per event
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
-      unsigned int   sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
+      std::uint32_t  sourceNameHash; ///< hash of sourceName, std::hash<std::string>(sourceName), then truncated to std::uint32_t. Should be 32-bit integer to be used as TTreeIndex (https://root.cern/doc/master/classTTreeIndex.html#a08aac749ab22fd5c8ab792a0061a4b0f)
       unsigned int   sourceIndex = NoSourceIndex(); ///< Index of this event within the source (zero-based).
 
       /// If true, this record has been filterd out, and only remains as a

--- a/sbnanaobj/StandardRecord/SRTrueInteraction.h
+++ b/sbnanaobj/StandardRecord/SRTrueInteraction.h
@@ -43,6 +43,7 @@ namespace caf
     int   hitnuc;
     genie_interaction_mode_ genie_mode;   //!< Interaction mode (as for LArSoft MCNeutrino::Mode() )
     genie_interaction_type_ genie_inttype; //!< Following LARSoft MCNeutrino::InteractionType()
+    size_t genie_evtrec_idx; //!< Index in the genie::NtpMCEventRecord
 
     bool    isnc;              //!< same as LArSoft "ccnc" - 0=CC, 1=NC
     bool    iscc;              //!< CC (true) or NC/interference (false)

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -11,7 +11,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="21">
+  <class name="caf::SRHeader" ClassVersion="22">
+   <version ClassVersion="22" checksum="4065646786"/>
    <version ClassVersion="21" checksum="755284079"/>
    <version ClassVersion="20" checksum="2820677622"/>
    <version ClassVersion="19" checksum="3510140996"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -176,7 +176,8 @@
    <version ClassVersion="10" checksum="3963837747"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="13">
+  <class name="caf::SRTrueInteraction" ClassVersion="14">
+   <version ClassVersion="14" checksum="2387261293"/>
    <version ClassVersion="13" checksum="2387159424"/>
    <version ClassVersion="12" checksum="671928574"/>
    <version ClassVersion="11" checksum="1242940498"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -11,7 +11,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="20">
+  <class name="caf::SRHeader" ClassVersion="21">
+   <version ClassVersion="21" checksum="755284079"/>
    <version ClassVersion="20" checksum="2820677622"/>
    <version ClassVersion="19" checksum="3510140996"/>
    <version ClassVersion="18" checksum="1724302139"/>


### PR DESCRIPTION
Adding a new `size_t` variable into `SRTrueInteraction` which corresponds to the index of the corresponding `genie::EventRecord` from the newly added GENIE tree into caf (https://github.com/SBNSoftware/sbncode/pull/426).
The matching between SRTrueInteraction object from `recTree` and `genie::EventRecord` can be done by this index.