### PR TITLE
Adding GENIE Tree index to SRTrueInteraction [release/SBN2024A]

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -32,6 +32,7 @@ namespace caf
   noffbeambnb(0.0),
   nnumiinfo(0),
   noffbeamnumi(0.0),
+  sourceNameHash(0),
   husk(false)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -10,6 +10,7 @@
 #include "sbnanaobj/StandardRecord/SRNuMIInfo.h"
 #include "sbnanaobj/StandardRecord/SRTrigger.h"
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <limits> // std::numeric_limits
@@ -56,7 +57,7 @@ namespace caf
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
       unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
-      unsigned int   sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
+      std::uint32_t  sourceNameHash; ///< hash of sourceName, std::hash<std::string>(sourceName), then truncated to std::uint32_t. Should be 32-bit integer to be used as TTreeIndex (https://root.cern/doc/master/classTTreeIndex.html#a08aac749ab22fd5c8ab792a0061a4b0f)
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -56,7 +56,7 @@ namespace caf
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
       unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
-      size_t         sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
+      unsigned int   sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any

--- a/sbnanaobj/StandardRecord/SRHeader.h
+++ b/sbnanaobj/StandardRecord/SRHeader.h
@@ -56,6 +56,7 @@ namespace caf
 
       std::string    sourceName; ///< Name of the file or source this event comes from.
       unsigned int   sourceIndex = NoSourceIndex; ///< Index of this event within the source (zero-based).
+      size_t         sourceNameHash; ///< hash of sourceName; std::hash<std::string>(sourceName)
 
       /// If true, this record has been filterd out, and only remains as a
       /// receptacle for exposure information. It should be skipped in any

--- a/sbnanaobj/StandardRecord/SRTrueInteraction.cxx
+++ b/sbnanaobj/StandardRecord/SRTrueInteraction.cxx
@@ -24,6 +24,7 @@ namespace caf
     hitnuc(-999),
     genie_mode(kUnknownInteractionMode),
     genie_inttype(kUnknownInteractionType),
+    genie_evtrec_idx(0),
     isnc(false),
     iscc(false),
     isvtxcont(false),

--- a/sbnanaobj/StandardRecord/SRTrueInteraction.h
+++ b/sbnanaobj/StandardRecord/SRTrueInteraction.h
@@ -43,6 +43,7 @@ namespace caf
     int   hitnuc;
     genie_interaction_mode_ genie_mode;   //!< Interaction mode (as for LArSoft MCNeutrino::Mode() )
     genie_interaction_type_ genie_inttype; //!< Following LARSoft MCNeutrino::InteractionType()
+    size_t genie_evtrec_idx; //!< Index in the genie::NtpMCEventRecord
 
     bool    isnc;              //!< same as LArSoft "ccnc" - 0=CC, 1=NC
     bool    iscc;              //!< CC (true) or NC/interference (false)

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -193,7 +193,8 @@
    <version ClassVersion="10" checksum="3963837747"/>
   </class>
 
-  <class name="caf::SRTrueInteraction" ClassVersion="13">
+  <class name="caf::SRTrueInteraction" ClassVersion="14">
+   <version ClassVersion="14" checksum="2387261293"/>
    <version ClassVersion="13" checksum="2387159424"/>
    <version ClassVersion="12" checksum="671928574"/>
    <version ClassVersion="11" checksum="1242940498"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -12,7 +12,8 @@
    <version ClassVersion="10" checksum="2569909752"/>
   </class>
 
-  <class name="caf::SRHeader" ClassVersion="21">
+  <class name="caf::SRHeader" ClassVersion="22">
+   <version ClassVersion="22" checksum="4182630414"/>
    <version ClassVersion="21" checksum="861604402"/>
    <version ClassVersion="20" checksum="185218613"/>
    <version ClassVersion="19" checksum="1204111507"/>


### PR DESCRIPTION
This is a copy of https://github.com/SBNSoftware/sbnanaobj/pull/128  (on develop) or https://github.com/SBNSoftware/sbnanaobj/pull/124  (on release/SBN2023A_NuMI).

Adding a new `size_t genie_evtrec_idx` variable into `SRTrueInteraction` which corresponds to the index of the corresponding `genie::EventRecord`.
Also added `std::uint32_t sourceNameHash`, where we save the truncated hash of `sourceName`; this can be used when matching to auxiliary trees other than `recTree`.
