### PR TITLE
Having defaults for sourceNameHash and genie_evtrec_idx

### DIFF
--- a/sbnanaobj/StandardRecord/SRHeader.cxx
+++ b/sbnanaobj/StandardRecord/SRHeader.cxx
@@ -32,6 +32,7 @@ namespace caf
   noffbeambnb(0.0),
   nnumiinfo(0),
   noffbeamnumi(0.0),
+  sourceNameHash(0),
   husk(false)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRTrueInteraction.cxx
+++ b/sbnanaobj/StandardRecord/SRTrueInteraction.cxx
@@ -24,6 +24,7 @@ namespace caf
     hitnuc(-999),
     genie_mode(kUnknownInteractionMode),
     genie_inttype(kUnknownInteractionType),
+    genie_evtrec_idx(0),
     isnc(false),
     iscc(false),
     isvtxcont(false),


### PR DESCRIPTION
Setting default values for one of the new variables we added to prevent failure in CI validation. Here I cherry-picked from the commits made for https://github.com/SBNSoftware/sbnanaobj/pull/131 for develop branch.