### PR TITLE
Setting default values for variables

### DIFF
--- a/sbnanaobj/StandardRecord/SRShower.cxx
+++ b/sbnanaobj/StandardRecord/SRShower.cxx
@@ -35,7 +35,7 @@ namespace caf
     start(kInvalid, kInvalid, kInvalid),
     end(kInvalid, kInvalid, kInvalid),
     cosmicDist(-5.f),
-    producer(-5.0)
+    producer(9999999)
   {
   }
 

--- a/sbnanaobj/StandardRecord/SRShower.cxx
+++ b/sbnanaobj/StandardRecord/SRShower.cxx
@@ -34,7 +34,8 @@ namespace caf
     dir(kInvalid, kInvalid, kInvalid),
     start(kInvalid, kInvalid, kInvalid),
     end(kInvalid, kInvalid, kInvalid),
-    cosmicDist(-5.f)
+    cosmicDist(-5.f),
+    producer(-5.0)
   {
   }
 

--- a/sbnanaobj/StandardRecord/SRTrack.cxx
+++ b/sbnanaobj/StandardRecord/SRTrack.cxx
@@ -20,7 +20,8 @@ namespace caf
     npts(-1),
     len(kInvalid),
     costh(kInvalid),
-    phi(kInvalid)
+    phi(kInvalid),
+    bestplane(Plane_t::kUnknown)
   {
   }
 } // end namespace caf


### PR DESCRIPTION
Setting default values for `trk.bestplane` and `shw.producer`. When the sbnd CI was being ran differences in the caf stage were appearing due to these variables not being initialised with a default value. Warnings looked like:

```
664:   rec.slc[0].reco.pfp[0].shw.producer differs: 632172960 vs 622129504
665:   rec.slc[0].reco.pfp[0].trk.bestplane differs: 786776544 vs -1706641423
```

This change sets default values for these variables, removing this warning from the CI. 