### PR TITLE
add first NuGraph2 info to CAF

### DIFF
--- a/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
@@ -1,16 +1,1 @@
 #include "sbnanaobj/StandardRecord/SRNuGraphScore.h"
-#include <limits>
-
-namespace caf
-{
-  SRNuGraphScore::SRNuGraphScore() :
-    sem_cat(NuGraphCategory::Unset),
-    mip_frac(std::numeric_limits<float>::signaling_NaN()),
-    hip_frac(std::numeric_limits<float>::signaling_NaN()),
-    shr_frac(std::numeric_limits<float>::signaling_NaN()),
-    mhl_frac(std::numeric_limits<float>::signaling_NaN()),
-    dif_frac(std::numeric_limits<float>::signaling_NaN()),
-    bkg_frac(std::numeric_limits<float>::signaling_NaN())
-  {
-  }
-}

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
@@ -1,0 +1,16 @@
+#include "sbnanaobj/StandardRecord/SRNuGraphScore.h"
+#include <limits>
+
+namespace caf
+{
+  SRNuGraphScore::SRNuGraphScore() :
+    sem_cat(NuGraphCategory::Unset),
+    mip_frac(std::numeric_limits<float>::signaling_NaN()),
+    hip_frac(std::numeric_limits<float>::signaling_NaN()),
+    shr_frac(std::numeric_limits<float>::signaling_NaN()),
+    mhl_frac(std::numeric_limits<float>::signaling_NaN()),
+    dif_frac(std::numeric_limits<float>::signaling_NaN()),
+    bkg_frac(std::numeric_limits<float>::signaling_NaN())
+  {
+  }
+}

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////
+// \file    SRNuGraphScore.h
+////////////////////////////////////////////////////////////////////////
+#ifndef SRNuGraphSCORE_H
+#define SRNuGraphSCORE_H
+
+namespace caf {
+
+  class SRNuGraphScore {
+  public:
+    SRNuGraphScore();
+    ~SRNuGraphScore() {}
+
+    enum NuGraphCategory {
+      Unset = -1,
+      Mip = 0,
+      Hip = 1,
+      Shower = 2,
+      Michel = 3,
+      Diffuse = 4
+    };
+
+    int sem_cat;
+    float mip_frac;
+    float hip_frac;
+    float shr_frac;
+    float mhl_frac;
+    float dif_frac;
+    float bkg_frac;
+  };
+}
+
+#endif

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -4,7 +4,7 @@
 #ifndef SRNuGraphSCORE_H
 #define SRNuGraphSCORE_H
 
-#include <limits>
+#include "sbnanaobj/StandardRecord/SRConstants.h"
 
 /**
  * @brief Categorization of the object/PFP by NuGraph.
@@ -29,14 +29,13 @@ namespace caf {
       Diffuse = 4 ///< Diffuse activity.
     };
 
-    int sem_cat =  = NuGraphCategory::Unset;
-    static constexpr float kUnassigned = std::numeric_limits<float>::signaling_NaN();
-    float mip_frac = kUnassigned; ///< Fraction of hits that are labeled as `MIP`.
-    float hip_frac = kUnassigned; ///< Fraction of hits that are labeled as `HIP`.
-    float shr_frac = kUnassigned; ///< Fraction of hits that are labeled as `Shower`.
-    float mhl_frac = kUnassigned; ///< Fraction of hits that are labeled as `Michel`.
-    float dif_frac = kUnassigned; ///< Fraction of hits that are labeled as `Diffuse`.
-    float bkg_frac = kUnassigned; ///< Fraction of hits that are labeled as `Background`.
+    int sem_cat = NuGraphCategory::Unset;
+    float mip_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `MIP`.
+    float hip_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `HIP`.
+    float shr_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Shower`.
+    float mhl_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Michel`.
+    float dif_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Diffuse`.
+    float bkg_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Background`.
   };
 }
 

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -4,29 +4,39 @@
 #ifndef SRNuGraphSCORE_H
 #define SRNuGraphSCORE_H
 
+#include <limits>
+
+/**
+ * @brief Categorization of the object/PFP by NuGraph.
+ *
+ * This object summarizes the results from running NuGraph over hits in a slice
+ * (see e.g. [https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585](SBN DocDB 40585).
+ *
+ * The semantic category is the one that most hits belong to.
+ * The fractions describe the categorization of the hits in the object/PFP.
+ */
 namespace caf {
 
   class SRNuGraphScore {
   public:
-    SRNuGraphScore();
-    ~SRNuGraphScore() {}
 
     enum NuGraphCategory {
-      Unset = -1,
-      Mip = 0,
-      Hip = 1,
-      Shower = 2,
-      Michel = 3,
-      Diffuse = 4
+      Unset = -1, ///< Unset/unknown/undecided/ category.
+      MIP = 0,    ///< Minimum-ionizing particle.
+      HIP = 1,    ///< Highly-ionizing particle.
+      Shower = 2, ///< EM Shower (photon or primary electron).
+      Michel = 3, ///< Michel electron (from muon decay).
+      Diffuse = 4 ///< Diffuse activity.
     };
 
-    int sem_cat;
-    float mip_frac;
-    float hip_frac;
-    float shr_frac;
-    float mhl_frac;
-    float dif_frac;
-    float bkg_frac;
+    int sem_cat =  = NuGraphCategory::Unset;
+    static constexpr float kUnassigned = std::numeric_limits<float>::signaling_NaN();
+    float mip_frac = kUnassigned; ///< Fraction of hits that are labeled as `MIP`.
+    float hip_frac = kUnassigned; ///< Fraction of hits that are labeled as `HIP`.
+    float shr_frac = kUnassigned; ///< Fraction of hits that are labeled as `Shower`.
+    float mhl_frac = kUnassigned; ///< Fraction of hits that are labeled as `Michel`.
+    float dif_frac = kUnassigned; ///< Fraction of hits that are labeled as `Diffuse`.
+    float bkg_frac = kUnassigned; ///< Fraction of hits that are labeled as `Background`.
   };
 }
 

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -6,17 +6,17 @@
 
 #include "sbnanaobj/StandardRecord/SRConstants.h"
 
-/**
- * @brief Categorization of the object/PFP by NuGraph.
- *
- * This object summarizes the results from running NuGraph over hits in a slice
- * (see e.g. [https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585](SBN DocDB 40585).
- *
- * The semantic category is the one that most hits belong to.
- * The fractions describe the categorization of the hits in the object/PFP.
- */
 namespace caf {
 
+  /**
+  * @brief Categorization of the object/PFP by NuGraph.
+  *
+  * This object summarizes the results from running NuGraph over hits in a slice
+  * (see e.g. [https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585](SBN DocDB 40585).
+  *
+  * The semantic category is the one that most hits belong to.
+  * The fractions describe the categorization of the hits in the object/PFP.
+  */
   class SRNuGraphScore {
   public:
 

--- a/sbnanaobj/StandardRecord/SRPFP.h
+++ b/sbnanaobj/StandardRecord/SRPFP.h
@@ -32,7 +32,7 @@ class SRPFP {
 
   SRCNNScore cnnscore; // CNN scores for this PFP
 
-  SRNuGraphScore ngscore; // NuGraph scores for this PFP
+  SRNuGraphScore ngscore; //< NuGraph scores for this PFP
 
   int slcID; // ID of the slice that this PFP belongs to
   float t0; // T0 assigned by TPC reco, if any

--- a/sbnanaobj/StandardRecord/SRPFP.h
+++ b/sbnanaobj/StandardRecord/SRPFP.h
@@ -9,6 +9,7 @@
 #include "sbnanaobj/StandardRecord/SRShower.h"
 #include "sbnanaobj/StandardRecord/SRPFPRazzled.h"
 #include "sbnanaobj/StandardRecord/SRCNNScore.h"
+#include "sbnanaobj/StandardRecord/SRNuGraphScore.h"
 
 #include <vector>
 
@@ -31,13 +32,7 @@ class SRPFP {
 
   SRCNNScore cnnscore; // CNN scores for this PFP
 
-  int   ng_sem_cat;    ///< NuGraph semantic category with largest hit fraction
-  float ng_mip_frac; ///< Fraction of PFP hits labeled by NuGraph as MIP
-  float ng_hip_frac; ///< Fraction of PFP hits labeled by NuGraph as HIP
-  float ng_shr_frac; ///< Fraction of PFP hits labeled by NuGraph as shower
-  float ng_mhl_frac; ///< Fraction of PFP hits labeled by NuGraph as Michel
-  float ng_dif_frac; ///< Fraction of PFP hits labeled by NuGraph as diffuse
-  float ng_bkg_frac; ///< Fraction of PFP hits labeled by NuGraph as background
+  SRNuGraphScore ngscore; // NuGraph scores for this PFP
 
   int slcID; // ID of the slice that this PFP belongs to
   float t0; // T0 assigned by TPC reco, if any

--- a/sbnanaobj/StandardRecord/SRPFP.h
+++ b/sbnanaobj/StandardRecord/SRPFP.h
@@ -31,6 +31,14 @@ class SRPFP {
 
   SRCNNScore cnnscore; // CNN scores for this PFP
 
+  int   ng_sem_cat;    ///< NuGraph semantic category with largest hit fraction
+  float ng_mip_frac; ///< Fraction of PFP hits labeled by NuGraph as MIP
+  float ng_hip_frac; ///< Fraction of PFP hits labeled by NuGraph as HIP
+  float ng_shr_frac; ///< Fraction of PFP hits labeled by NuGraph as shower
+  float ng_mhl_frac; ///< Fraction of PFP hits labeled by NuGraph as Michel
+  float ng_dif_frac; ///< Fraction of PFP hits labeled by NuGraph as diffuse
+  float ng_bkg_frac; ///< Fraction of PFP hits labeled by NuGraph as background
+
   int slcID; // ID of the slice that this PFP belongs to
   float t0; // T0 assigned by TPC reco, if any
 

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -56,6 +56,7 @@ namespace caf
       bool is_clear_cosmic { false };         //!< Whether pandora marks the slice as a "clear" cosmic
       int nu_pdg           { INT_MIN };       //!< PDG assigned to the PFParticle Neutrino
       float nu_score       { kSignalingNaN }; //!< Score of how neutrino-like the slice is according to pandora
+      float ng_filt_pass_frac { kSignalingNaN }; //!< Fraction of slice hits that pass the nugraph filter decoder
       SRCRUMBSResult crumbs_result;  //!< Score of how neutrino-like the slice is according to the CRUMBS ID
 
       SRNuID nuid; //!< Neutrino ID Features (BDT inputs) going into nu_score calculation

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -67,7 +67,9 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="21">
+  <class name="caf::SRSlice" ClassVersion="23">
+   <version ClassVersion="23" checksum="2124497341"/>
+   <version ClassVersion="22" checksum="4187618741"/>
    <version ClassVersion="21" checksum="3825441135"/>
    <version ClassVersion="20" checksum="1917004696"/>
    <version ClassVersion="19" checksum="3108582545"/>
@@ -241,7 +243,9 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
-  <class name="caf::SRPFP" ClassVersion="15">
+  <class name="caf::SRPFP" ClassVersion="17">
+   <version ClassVersion="17" checksum="135310109"/>
+   <version ClassVersion="16" checksum="1684266144"/>
    <version ClassVersion="15" checksum="3226426358"/>
    <version ClassVersion="14" checksum="635023057"/>
    <version ClassVersion="13" checksum="2132348118"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -242,7 +242,8 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
-  <class name="caf::SRPFP" ClassVersion="16">
+  <class name="caf::SRPFP" ClassVersion="17">
+   <version ClassVersion="17" checksum="2252062519"/>
    <version ClassVersion="16" checksum="135310109"/>
    <version ClassVersion="15" checksum="3226426358"/>
    <version ClassVersion="14" checksum="635023057"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -42,6 +42,10 @@
    <version ClassVersion="10" checksum="3242119722"/>
   </class>
 
+  <class name="caf::SRNuGraphScore" ClassVersion="10" >
+   <version ClassVersion="10" checksum="705810055"/>
+  </class>
+
   <class name="caf::SRHit" ClassVersion="10">
    <version ClassVersion="10" checksum="1494967532"/>
   </class>
@@ -242,9 +246,8 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
-  <class name="caf::SRPFP" ClassVersion="17">
-   <version ClassVersion="17" checksum="2252062519"/>
-   <version ClassVersion="16" checksum="135310109"/>
+  <class name="caf::SRPFP" ClassVersion="16">
+   <version ClassVersion="16" checksum="2252062519"/>
    <version ClassVersion="15" checksum="3226426358"/>
    <version ClassVersion="14" checksum="635023057"/>
    <version ClassVersion="13" checksum="2132348118"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -67,9 +67,8 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="23">
-   <version ClassVersion="23" checksum="2124497341"/>
-   <version ClassVersion="22" checksum="4187618741"/>
+  <class name="caf::SRSlice" ClassVersion="22">
+   <version ClassVersion="22" checksum="2124497341"/>
    <version ClassVersion="21" checksum="3825441135"/>
    <version ClassVersion="20" checksum="1917004696"/>
    <version ClassVersion="19" checksum="3108582545"/>
@@ -243,9 +242,8 @@
    <version ClassVersion="10" checksum="839301601"/>
   </class>
 
-  <class name="caf::SRPFP" ClassVersion="17">
-   <version ClassVersion="17" checksum="135310109"/>
-   <version ClassVersion="16" checksum="1684266144"/>
+  <class name="caf::SRPFP" ClassVersion="16">
+   <version ClassVersion="16" checksum="135310109"/>
    <version ClassVersion="15" checksum="3226426358"/>
    <version ClassVersion="14" checksum="635023057"/>
    <version ClassVersion="13" checksum="2132348118"/>


### PR DESCRIPTION
This PR adds a few NuGraph-related variables to CAFs, along the lines of what presented on [docdb 40585](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585). Once SBNSoftware/icaruscode#815 is merged the needed data products can be produced, but it won't break CAF making if they are not there. The related SBNSoftware/sbncode#532 is also being made.
