### PR TITLE
Add tpc attribute to SROpFlash

### DIFF
--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -16,9 +16,9 @@ namespace caf
 
   void SROpFlash::setDefault()
   {
-
     onbeamtime       =   false;
     cryo             =      -5;
+    tpc              =      -5;  
     firstpmt         =      -5;
     time             = -9999.f;
     timewidth        =    -5.f;

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -21,6 +21,7 @@ namespace caf
     bool  onbeamtime       { false                        }; //!< Is this in time with beam?
     int   cryo             { kUninitializedInt            }; //!< 0 for SBND/ICARUS East, 1 for ICARUS West.
     int   firstpmt         { kUninitializedInt            }; //!< Channel number of first hit
+    int   tpc              { kUninitializedInt            }; //!< 0 for ICARUS, 0/1 for SBND
     float time             { kSignalingNaN                }; //!< Time on trigger time scale [us].
     float timewidth        { kSignalingNaN                }; //!< Width of the flash in time [us].
     float timemean         { kSignalingNaN                }; //!< Mean time of hits [us].

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -358,11 +358,13 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
-  <class name="caf::SROpFlash" ClassVersion="12">
+  <class name="caf::SROpFlash" ClassVersion="13">
+   <version ClassVersion="13" checksum="2333809763"/>
    <version ClassVersion="12" checksum="3122666215"/>
    <version ClassVersion="11" checksum="2756572285"/>
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
+
   <class name="std::vector<caf::SROpFlash>" />
   <class name="caf::SRCRTPMTMatch" ClassVersion="10" >
    <version ClassVersion="10" checksum="2059576953"/>


### PR DESCRIPTION
This PR adds the attribute tpc into the SROpFlash object. This is required for saving the OpFlash information in SBND in CAF files.