### PR TITLE
Extended information on the CRTHitT0Matching

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTHitMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTHitMatch.cxx
@@ -8,7 +8,15 @@ namespace caf
 {
 
   SRCRTHitMatch::SRCRTHitMatch():
-    distance(std::numeric_limits<float>::signaling_NaN())
+    distance(std::numeric_limits<float>::signaling_NaN()),
+    region(-1),
+    sys(-1),
+    deltaX(std::numeric_limits<float>::signaling_NaN()),
+    deltaY(std::numeric_limits<float>::signaling_NaN()),
+    deltaZ(std::numeric_limits<float>::signaling_NaN()),
+    crossX(std::numeric_limits<float>::signaling_NaN()),
+    crossY(std::numeric_limits<float>::signaling_NaN()),
+    crossZ(std::numeric_limits<float>::signaling_NaN())
   {}
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTHitMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTHitMatch.h
@@ -17,7 +17,15 @@ namespace caf
       SRCRTHitMatch();
       virtual ~SRCRTHitMatch() {}
       SRCRTHit hit; ///< The CRT hit
-      float distance; ///< Distance from the projected TPC track to the CRT hit [cm]
+      float distance; ///< Distance from the extrapolated TPC track to the CRT hit [cm]
+      int region; ///< region of the matched crt plane
+      int sys; ///< system of the matched crt hit (e.g. ICARUS: Top 0, Side 1, Bottom 2)
+      float deltaX; ///< DeltaX between CRT Hit matched and the track extrapolation onto the CRT plane
+      float deltaY; ///< DeltaY between CRT Hit matched and the track extrapolation onto the CRT plane
+      float deltaZ; ///< DeltaZ between CRT Hit matched and the track extrapolation onto the CRT plane
+      float crossX; ///< Extrapolated track crossing point onto the CRT plane
+      float crossY; ///< Extrapolated track crossing point onto the CRT plane
+      float crossZ; ///< Extrapolated track crossing point onto the CRT plane
     };
 
 } // end namespace

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -350,7 +350,8 @@
   </class>
   <class name="std::vector<caf::SRCRTTrack>" />
 
-  <class name="caf::SRCRTHitMatch" ClassVersion="10">
+  <class name="caf::SRCRTHitMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="900891432"/>
    <version ClassVersion="10" checksum="1521467565"/>
   </class>
 


### PR DESCRIPTION
This PR adds additional information on the Standard Record: SRCRTHitMatch which are useful for the analyzers.