### PR TITLE
Initialise opt0 vars in CRUMBS result

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
+++ b/sbnanaobj/StandardRecord/SRCRUMBSResult.cxx
@@ -26,6 +26,8 @@ namespace caf {
     : fmtotalscore(std::numeric_limits<float>::signaling_NaN())
     , fmpe(std::numeric_limits<float>::signaling_NaN())
     , fmtime(std::numeric_limits<float>::signaling_NaN())
+    , opt0score(std::numeric_limits<float>::signaling_NaN())
+    , opt0measuredpe(std::numeric_limits<float>::signaling_NaN())
   {
   }
 


### PR DESCRIPTION
@nathanielerowe pointed out some CI tests were showing variation in the opt0 variables in the CAFs CRUMBS object.

Theory that this results from the lack of initialisation of these variables (seems highly likely). Looks like I never added the initialisation when CRUMBS was updated to use OpT0 as well as SimpleFlash. This PR fixes that.