### PR TITLE
Add PMT Beam Signal timing to ICARUS CAFs 

### DIFF
--- a/sbnanaobj/StandardRecord/SROpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SROpFlash.cxx
@@ -25,6 +25,7 @@ namespace caf
     timemean         = -9999.f;
     timesd           =    -5.f;
     firsttime        = -9999.f;
+    rwmtime          = -9999.f;
     totalpe          =    -5.f;
     fasttototal      =    -5.f;
     peperwall[0] = -5.f;

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -27,7 +27,7 @@ namespace caf
     float timemean         { kSignalingNaN                }; //!< Mean time of hits [us].
     float timesd           { kSignalingNaN                }; //!< Standard deviation of hit times [us].
     float firsttime        { kSignalingNaN                }; //!< Time of first hit [us].
-    float rwmtime          { kSignalingNaN                }; //!< Time of flash wrt RWM Time. 
+    float rwmtime          { kSignalingNaN                }; //!< Time of flash wrt RWM Time [us]. 
     float totalpe          { kSignalingNaN                }; //!< Total number of PE across all PMTs.
     float fasttototal      { kSignalingNaN                }; //!< Fast to total light ratio.
     float peperwall[2] { kSignalingNaN, kSignalingNaN };

--- a/sbnanaobj/StandardRecord/SROpFlash.h
+++ b/sbnanaobj/StandardRecord/SROpFlash.h
@@ -27,6 +27,7 @@ namespace caf
     float timemean         { kSignalingNaN                }; //!< Mean time of hits [us].
     float timesd           { kSignalingNaN                }; //!< Standard deviation of hit times [us].
     float firsttime        { kSignalingNaN                }; //!< Time of first hit [us].
+    float rwmtime          { kSignalingNaN                }; //!< Time of flash wrt RWM Time. 
     float totalpe          { kSignalingNaN                }; //!< Total number of PE across all PMTs.
     float fasttototal      { kSignalingNaN                }; //!< Fast to total light ratio.
     float peperwall[2] { kSignalingNaN, kSignalingNaN };

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -365,7 +365,8 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
-  <class name="caf::SROpFlash" ClassVersion="13">
+  <class name="caf::SROpFlash" ClassVersion="14">
+   <version ClassVersion="14" checksum="1680515282"/>
    <version ClassVersion="13" checksum="2333809763"/>
    <version ClassVersion="12" checksum="3122666215"/>
    <version ClassVersion="11" checksum="2756572285"/>


### PR DESCRIPTION
This pull request adds a new variable to SROpFlash where the OpFlash time wrt the RWM time will be stored. Having this variable at the CAF level allows us to reconstruct the Beam Bunch structure seen by ICARUS PMTs. 

This PR is a companion to sbncode PR ### and will require [icaruscode PR #832](https://github.com/SBNSoftware/icaruscode/pull/832) and  [sbnobj PR #130 ](https://github.com/SBNSoftware/sbnobj/pull/130) to also be merged.