### PR TITLE
adding efield and phi to SRCaloPoint

### DIFF
--- a/sbnanaobj/StandardRecord/SRCaloPoint.cxx
+++ b/sbnanaobj/StandardRecord/SRCaloPoint.cxx
@@ -15,6 +15,8 @@ namespace caf
     dedx(std::numeric_limits<float>::signaling_NaN()),
     pitch(std::numeric_limits<float>::signaling_NaN()),
     t(std::numeric_limits<float>::signaling_NaN()),
+    efield(std::numeric_limits<float>::signaling_NaN()),
+    phi(std::numeric_limits<float>::signaling_NaN()),
     x(std::numeric_limits<float>::signaling_NaN()),
     y(std::numeric_limits<float>::signaling_NaN()),
     z(std::numeric_limits<float>::signaling_NaN()),

--- a/sbnanaobj/StandardRecord/SRCaloPoint.h
+++ b/sbnanaobj/StandardRecord/SRCaloPoint.h
@@ -20,6 +20,8 @@ namespace caf
       float dedx; //!< dQ/dx [ADC/cm] -- pre calibration and electron lifetime correction
       float pitch; //!< Track pitch [cm]
       float t; //!< Time of deposition [ticks]
+      float efield; //! |E| [kV/cm]
+      float phi; //! angle between the E-field and track dir for the hit, used in the GnocchiCalorimetry module
       // NOTE: flatten-caf seems to have trouble with nesting the point
       // inside a SRVector3D -- so just expose x/y/z out here
       float x; //!< X-Position of deposition [cm]


### PR DESCRIPTION
Adding `efield` and `phi` to sbnanaobj/StandardRecord/SRCaloPoint.cxx.
This is a follow up for recent updates from LArSoft's side in larreco and lardataobj which are tagged from v10_02_00 of them ([PR #52 in lardataobj](https://github.com/LArSoft/lardataobj/pull/52), [PR #82 in larreco](https://github.com/LArSoft/larreco/pull/82)).

Two additional variables, `efield` and `phi`, at CAF-level will be very helpful for trying various TPC calorimetry parameters (e-lifetime, electron-agon recombination models, calibration constants, ...) in CAF-analyzing level in flight.

Related PR in sbncode: []
