### PR TITLE
Fix CorrectedOpFlash attributes

### DIFF
--- a/sbnanaobj/StandardRecord/SRCorrectedOpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SRCorrectedOpFlash.cxx
@@ -14,11 +14,9 @@ namespace caf
   void SRCorrectedOpFlash::setDefault()
   {
     OpFlashT0             =                             -9999.;
-    UpstreamTime_lightonly =                             -9999.;
-    UpstreamTime_tpczcorr  =                             -9999.;
-    UpstreamTime_propcorr_tpczcorr =                     -9999.;
-    SliceNuScore          =                             -9999.;
-    FMScore               =                             -9999.;
+    NuToFLight            =                             -9999.;
+    NuToFCharge           =                             -9999.;
+    OpFlashT0Corrected    =                             -9999.;
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRCorrectedOpFlash.h
+++ b/sbnanaobj/StandardRecord/SRCorrectedOpFlash.h
@@ -18,11 +18,9 @@ namespace caf
     /// @name Data members related to the opflash corrected time
     /// @{
     float        OpFlashT0             { -9999. };                   ///< | OpFlash Time wrt RWM time | (ns)
-    float        UpstreamTime_lightonly             {  -9999.  };      ///< | Nu upstream wall time reconstructed using light only | (ns)
-    float        UpstreamTime_tpczcorr             {  -9999.  };       ///< | Nu upstream wall time reconstructed using light and Z from tpc vertex | (ns)
-    float        UpstreamTime_propcorr_tpczcorr    {  -9999.  };       ///< | Nu upstream wall time reconstructed using light propagation correction from tpc information and z correction from tpc vertex | (ns)
-    float        SliceNuScore             {  -9999.  };                   ///< | Slice Nu Score |
-    float        FMScore             {  -9999.  };                   ///< | Flash Match Score |
+    float        NuToFLight             {  -9999.  };      ///< | Nu ToF using light only | (ns)
+    float        NuToFCharge             {  -9999.  };       ///< | Nu ToF Z from tpc vertex | (ns)
+    float        OpFlashT0Corrected    {  -9999.  };       ///< | OpFlash Time wrt RWM time after light propagation corrections | (ns)
     /// @}
 
     void setDefault();


### PR DESCRIPTION
Remove CorrectedOpFlash attributes that can be found via slice-correctedopflash assns. It also changes the attributes to reflect each of the corrections separately. 