### PR TITLE
Add PTB trigger fields to SRTrigger for SBND

### DIFF
--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -43,6 +43,15 @@ namespace caf
     int num_pairs_over_threshold; ///< number of pmt pairs over trigger threshold
     std::vector<int> monpulses_flat; ///< trigger responses (number of PMT pairs above threshold for all channels) for all flashes (flattened to include all flashes in a single vector)
     std::vector<int> monpulse_sizes; ///< length of each trigger responses to un-flatten the trigger responses (to a vector of trigger responses)
+    
+    /// PTB (Penn Trigger Board) trigger information for SBND
+    /// SBND: straight from the trigger hardware.
+    /// HLT (High Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
+    std::vector<double> ptb_hlt_timestamp;         ///< Current timestamp for each HLT trigger bit [s]
+    std::vector<std::uint64_t> ptb_hlt_bit;       ///< Individual trigger bit number for each HLT trigger (decoded from trigger word)
+    /// LLT (Low Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
+    std::vector<double> ptb_llt_timestamp;         ///< Current timestamp for each LLT trigger bit [s]
+    std::vector<std::uint64_t> ptb_llt_bit;       ///< Individual trigger bit number for each LLT trigger (decoded from trigger word)
   };
 }
 

--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -48,14 +48,14 @@ namespace caf
      * @name SBND PTB (Penn Trigger Board) trigger information
      * 
      * SBND: straight from the trigger hardware.
-     * Both HLT (High Level Trigger) and LLT (Low Level Trigger) information - decoded:
-     * each set bit in the trigger word becomes a separate entry.
+     * Both HLT (High Level Trigger) and LLT (Low Level Trigger) information decoded from trigger word: each set bit in the trigger word becomes a separate entry with its own timestamp.
+     * Timestamp is in UTC nanoseconds since Unix epoch (converted from 20ns clock ticks)
      */
     /// @{
-    std::vector<std::uint64_t> ptb_hlt_timestamp; ///< Current timestamp for each HLT trigger bit [ns]
-    std::vector<std::uint8_t> ptb_hlt_bit; ///< Individual trigger bit number for each HLT trigger (decoded from trigger word
-    std::vector<std::uint64_t> ptb_llt_timestamp; ///< Current timestamp for each LLT trigger bit [ns]
-    std::vector<std::uint8_t> ptb_llt_bit; ///< Individual trigger bit number for each LLT trigger (decoded from trigger word
+    std::vector<std::uint64_t> ptb_hlt_timestamp; ///< Timestamp for each HLT bit that fired
+    std::vector<std::uint8_t> ptb_hlt_bit; ///< Bit number for each HLT that fired
+    std::vector<std::uint64_t> ptb_llt_timestamp; ///< Timestamp for each LLT bit that fired
+    std::vector<std::uint8_t> ptb_llt_bit; ///< Bit number for each LLT that fired
     /// @}
   };
 }

--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -48,10 +48,10 @@ namespace caf
     /// SBND: straight from the trigger hardware.
     /// HLT (High Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
     std::vector<double> ptb_hlt_timestamp;         ///< Current timestamp for each HLT trigger bit [s]
-    std::vector<std::uint64_t> ptb_hlt_bit;       ///< Individual trigger bit number for each HLT trigger (decoded from trigger word)
+    std::vector<std::uint8_t> ptb_hlt_bit;       ///< Individual trigger bit number for each HLT trigger (decoded from trigger word)
     /// LLT (Low Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
     std::vector<double> ptb_llt_timestamp;         ///< Current timestamp for each LLT trigger bit [s]
-    std::vector<std::uint64_t> ptb_llt_bit;       ///< Individual trigger bit number for each LLT trigger (decoded from trigger word)
+    std::vector<std::uint8_t> ptb_llt_bit;       ///< Individual trigger bit number for each LLT trigger (decoded from trigger word)
   };
 }
 

--- a/sbnanaobj/StandardRecord/SRTrigger.h
+++ b/sbnanaobj/StandardRecord/SRTrigger.h
@@ -44,14 +44,19 @@ namespace caf
     std::vector<int> monpulses_flat; ///< trigger responses (number of PMT pairs above threshold for all channels) for all flashes (flattened to include all flashes in a single vector)
     std::vector<int> monpulse_sizes; ///< length of each trigger responses to un-flatten the trigger responses (to a vector of trigger responses)
     
-    /// PTB (Penn Trigger Board) trigger information for SBND
-    /// SBND: straight from the trigger hardware.
-    /// HLT (High Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
-    std::vector<double> ptb_hlt_timestamp;         ///< Current timestamp for each HLT trigger bit [s]
-    std::vector<std::uint8_t> ptb_hlt_bit;       ///< Individual trigger bit number for each HLT trigger (decoded from trigger word)
-    /// LLT (Low Level Trigger) information - decoded: each set bit in the trigger word becomes a separate entry
-    std::vector<double> ptb_llt_timestamp;         ///< Current timestamp for each LLT trigger bit [s]
-    std::vector<std::uint8_t> ptb_llt_bit;       ///< Individual trigger bit number for each LLT trigger (decoded from trigger word)
+    /**
+     * @name SBND PTB (Penn Trigger Board) trigger information
+     * 
+     * SBND: straight from the trigger hardware.
+     * Both HLT (High Level Trigger) and LLT (Low Level Trigger) information - decoded:
+     * each set bit in the trigger word becomes a separate entry.
+     */
+    /// @{
+    std::vector<std::uint64_t> ptb_hlt_timestamp; ///< Current timestamp for each HLT trigger bit [ns]
+    std::vector<std::uint8_t> ptb_hlt_bit; ///< Individual trigger bit number for each HLT trigger (decoded from trigger word
+    std::vector<std::uint64_t> ptb_llt_timestamp; ///< Current timestamp for each LLT trigger bit [ns]
+    std::vector<std::uint8_t> ptb_llt_bit; ///< Individual trigger bit number for each LLT trigger (decoded from trigger word
+    /// @}
   };
 }
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -315,7 +315,8 @@
    <version ClassVersion="10" checksum="1010873394"/>
   </class>
 
-  <class name="caf::SRTrigger" ClassVersion="15">
+  <class name="caf::SRTrigger" ClassVersion="16">
+   <version ClassVersion="16" checksum="2105192063"/>
    <version ClassVersion="15" checksum="4174763051"/>
    <version ClassVersion="14" checksum="592461663"/>
    <version ClassVersion="13" checksum="1642667704"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -316,7 +316,7 @@
   </class>
 
   <class name="caf::SRTrigger" ClassVersion="16">
-   <version ClassVersion="16" checksum="2105192063"/>
+   <version ClassVersion="16" checksum="200062329"/>
    <version ClassVersion="15" checksum="4174763051"/>
    <version ClassVersion="14" checksum="592461663"/>
    <version ClassVersion="13" checksum="1642667704"/>


### PR DESCRIPTION
## Description
This PR adds PTB trigger information fields to the `SRTrigger` class in the StandardRecord structure, which is required for SBND trigger efficiency studies using zero bias data. HLT and LLT decoded bits and timestamps are stored in separate vectors for easier analysis. 

- [x] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [x] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [x] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [x] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?

