### PR TITLE
Light Calorimetry: add SRLightCalo and SRTrueDeposit classes

### DIFF
--- a/sbnanaobj/StandardRecord/SRLightCalo.h
+++ b/sbnanaobj/StandardRecord/SRLightCalo.h
@@ -17,10 +17,10 @@ namespace caf {
    * 
    */
   struct SRLightCalo {
-    float charge  = caf::kSignalingNaN;      // the total charge in the slice (on bestplane) [# electrons]
-    float light   = caf::kSignalingNaN;      // the reconstructed total number of photons  [# photons]
-    float energy  = caf::kSignalingNaN;      // (charge+light)*scaling, [GeV]
-    int bestplane = caf::kUninitializedInt;  // plane with most number of hits 
+    float charge  = caf::kSignalingNaN;      ///< the total charge in the slice (on bestplane) [# electrons]
+    float light   = caf::kSignalingNaN;      ///< the reconstructed total number of photons  [# photons]
+    float energy  = caf::kSignalingNaN;      ///< (charge+light)*scaling, [GeV]
+    int bestplane = caf::kUninitializedInt;  ///< plane with most number of hits 
 };
 }
 

--- a/sbnanaobj/StandardRecord/SRLightCalo.h
+++ b/sbnanaobj/StandardRecord/SRLightCalo.h
@@ -1,0 +1,27 @@
+/**
+ * @file   sbnanaobj/StandardRecord/SRLightCalo.h
+ * @brief  Defines data structures to store light calorimetry info (header only).
+ * @author Lynn Tung
+ * @date   November 19, 2025
+ */
+
+#ifndef SBNANAOBJ_STANDARDRECORD_SRLIGHTCALO_H
+#define SBNANAOBJ_STANDARDRECORD_SRLIGHTCALO_H
+
+#include "sbnanaobj/StandardRecord/SRConstants.h"
+
+namespace caf {
+
+  /**
+   * @brief A struct to store the reconstructed visible energy, light, and charge in a recob::Slice.
+   * 
+   */
+  struct SRLightCalo {
+    float charge  = caf::kSignalingNaN;      // the total charge in the slice (on bestplane) [# electrons]
+    float light   = caf::kSignalingNaN;      // the reconstructed total number of photons  [# photons]
+    float energy  = caf::kSignalingNaN;      // (charge+light)*scaling, [GeV]
+    int bestplane = caf::kUninitializedInt;  // plane with most number of hits 
+};
+}
+
+#endif

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -19,6 +19,7 @@
 #include "sbnanaobj/StandardRecord/SRNuID.h"
 #include "sbnanaobj/StandardRecord/SRConstants.h"
 #include "sbnanaobj/StandardRecord/SRCVNScore.h"
+#include "sbnanaobj/StandardRecord/SRLightCalo.h"
 
 #include <climits>
 
@@ -53,6 +54,8 @@ namespace caf
       SRTPCPMTBarycenterMatch barycenterFM; //!< Matching this slice to the OpFlash nearest to its charge center in YZ and to the triggering flash
 
       SRCorrectedOpFlash correctedOpFlash; //!< OpFlash corrected with using tpc information matched to this slice
+
+      SRLightCalo  lightcalo; // !< Reconstructed visible energy, light, and charge
 
       SRFakeReco fake_reco;
 

--- a/sbnanaobj/StandardRecord/SRTrueDeposit.h
+++ b/sbnanaobj/StandardRecord/SRTrueDeposit.h
@@ -1,0 +1,26 @@
+/**
+ * @file   sbnanaobj/StandardRecord/SrTrueDeposit.h
+ * @brief  Defines data structures to store summed SimEnergyDeposits (header only).
+ * @author Lynn Tung
+ * @date   November 18, 2025
+ */
+
+#ifndef SBNANAOBJ_STANDARDRECORD_SRTRUEDEPOSIT_H
+#define SBNANAOBJ_STANDARDRECORD_SRTRUEDEPOSIT_H
+
+#include "sbnanaobj/StandardRecord/SRConstants.h"
+
+namespace caf {
+
+  /**
+   * @brief A struct to store true deposited energy, charge, and photons for each MCTruth interaction.
+   * 
+   */
+  struct SRTrueDeposit {
+    float electrons = caf::kSignalingNaN; ///< # of electrons at the site of energy deposition (after recombination, before drift)
+    float photons   = caf::kSignalingNaN; ///< # of photons at the site of energy deposition   (after recombination, before propagation) 
+    float energy    = caf::kSignalingNaN; ///< total **deposited energy** [GeV]
+  };
+}
+
+#endif

--- a/sbnanaobj/StandardRecord/SRTrueDeposit.h
+++ b/sbnanaobj/StandardRecord/SRTrueDeposit.h
@@ -13,13 +13,13 @@
 namespace caf {
 
   /**
-   * @brief A struct to store true deposited energy, charge, and photons for each MCTruth interaction.
+   * @brief A struct to store total true deposited energy, charge, and photons for each MCTruth interaction.
    * 
    */
   struct SRTrueDeposit {
-    float electrons = caf::kSignalingNaN; ///< # of electrons at the site of energy deposition (after recombination, before drift)
-    float photons   = caf::kSignalingNaN; ///< # of photons at the site of energy deposition   (after recombination, before propagation) 
-    float energy    = caf::kSignalingNaN; ///< total **deposited energy** [GeV]
+    float electrons = caf::kSignalingNaN; ///< total # of electrons from the sites of energy deposition, summed per nu interaction (after recombination, before drift)
+    float photons   = caf::kSignalingNaN; ///< total # of photons from the sites of energy deposition, summed per nu interaction   (after recombination, before propagation) 
+    float energy    = caf::kSignalingNaN; ///< total **deposited energy**, summed per nu interaction [GeV]
   };
 }
 

--- a/sbnanaobj/StandardRecord/SRTruthBranch.h
+++ b/sbnanaobj/StandardRecord/SRTruthBranch.h
@@ -5,6 +5,7 @@
 #define SRTRUTHBRANCH_H
 
 #include "sbnanaobj/StandardRecord/SRTrueInteraction.h"
+#include "sbnanaobj/StandardRecord/SRTrueDeposit.h"
 #include "sbnanaobj/StandardRecord/SRMeVPrtl.h"
 
 #include <vector>
@@ -19,6 +20,7 @@ namespace caf
     ~SRTruthBranch();
             
     std::vector<SRTrueInteraction> nu;   ///< Vector of true nu or cosmic
+    std::vector<SRTrueDeposit>    dep;   ///< Vector of true energy deposits (summed), same size as nu
     size_t                        nnu;   ///< Number of true nu or cosmic
 
     std::vector<SRMeVPrtl>       prtl;   ///< If present -- information on decay of MeV "Portal" particle

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -95,6 +95,7 @@
   </class>
 
   <class name="caf::SROpT0Finder" />
+  <class name="caf::SRLightCalo" />
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="13">
    <version ClassVersion="13" checksum="4211357366"/>
@@ -174,6 +175,8 @@
    <version ClassVersion="10" checksum="4056415501"/>
   </class>
 
+  <class name="caf::SRTrueDeposit"/>
+
   <class name="caf::SRTrueParticlePlaneInfo" ClassVersion="11">
    <version ClassVersion="11" checksum="317847253"/>
    <version ClassVersion="10" checksum="1689803547"/>
@@ -215,7 +218,8 @@
    <version ClassVersion="10" checksum="1609299342"/>
   </class>
 
-  <class name="caf::SRTruthBranch" ClassVersion="11">
+  <class name="caf::SRTruthBranch" ClassVersion="12">
+   <version ClassVersion="12" checksum="3925767433"/>
    <version ClassVersion="11" checksum="1553456992"/>
    <version ClassVersion="10" checksum="2608785459"/>
   </class>
@@ -336,6 +340,7 @@
   <class name="std::vector<caf::SRTrueInteraction>" />
   <class name="std::vector<caf::SRMultiverse>" />
   <class name="std::vector<caf::SRTrueParticle>" />
+  <class name="std::vector<caf::SRTrueDeposit>" />
   <class name="std::vector<caf::SRParticleMatch>" />
   <class name="std::vector<caf::SRTrueCaloPoint>" />
   <class name="std::vector<caf::SRCaloPoint>" />

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -96,8 +96,13 @@
    <version ClassVersion="11" checksum="1429601394"/>
   </class>
 
-  <class name="caf::SROpT0Finder" />
-  <class name="caf::SRLightCalo" />
+  <class name="caf::SROpT0Finder" ClassVersion="10">
+   <version ClassVersion="10" checksum="1191492245"/>
+  </class>
+
+  <class name="caf::SRLightCalo" ClassVersion="10">
+   <version ClassVersion="10" checksum="1494722949"/>
+  </class>
 
   <class name="caf::SRSliceRecoBranch" ClassVersion="13">
    <version ClassVersion="13" checksum="4211357366"/>
@@ -182,7 +187,9 @@
    <version ClassVersion="10" checksum="4056415501"/>
   </class>
 
-  <class name="caf::SRTrueDeposit"/>
+  <class name="caf::SRTrueDeposit" ClassVersion="10">
+   <version ClassVersion="10" checksum="916262743"/>
+  </class>
 
   <class name="caf::SRTrueParticlePlaneInfo" ClassVersion="11">
    <version ClassVersion="11" checksum="317847253"/>


### PR DESCRIPTION
## Quick checklist

- [ ] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [x] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [ ] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [ ] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?

## Description

### `SRTRueDeposit`
SBND is currently keeping `SimEnergyDeposits` throughout the workflow. We can take better advantage of this information (truth level number of electrons, photons, and true energy deposits for true neutrino interactions) by adding it to the cafs. Default will be empty if no `SimEnergyDeposit`s are available in the input files. Only adds 3 floats per neutrino interaction (obtained from length of `MCTruth`).

### `SRLightCalo`
Class to fill _reconstructed_ number of electrons, photons, and energy deposits. 

Accompanying PRs: SBNSoftware/sbndcode#878, SBNSoftware/sbncode#619, SBNSoftware/sbnobj#158
