### PR TITLE
adding h_nelec_sed and h_e_sed to SRTrueCaloPoint for better recombination studies

### DIFF
--- a/sbnanaobj/StandardRecord/SRTrueCaloPoint.cxx
+++ b/sbnanaobj/StandardRecord/SRTrueCaloPoint.cxx
@@ -12,6 +12,8 @@ namespace caf
   SRTrueCaloPoint::SRTrueCaloPoint():
     h_nelec(std::numeric_limits<float>::signaling_NaN()),
     h_e(std::numeric_limits<float>::signaling_NaN()),
+    h_nelec_sed(std::numeric_limits<float>::signaling_NaN()),
+    h_e_sed(std::numeric_limits<float>::signaling_NaN()),
     p_nelec(std::numeric_limits<float>::signaling_NaN()),
     p_e(std::numeric_limits<float>::signaling_NaN()),
     x(std::numeric_limits<float>::signaling_NaN()),

--- a/sbnanaobj/StandardRecord/SRTrueCaloPoint.h
+++ b/sbnanaobj/StandardRecord/SRTrueCaloPoint.h
@@ -16,6 +16,8 @@ namespace caf
 
       float h_nelec; //!< Charge / number of electrons by hit
       float h_e; //!< Energy by hit [MeV]
+      float h_nelec_sed; //!< number of electrons from simEnergyDeposit (sed) in wire z +- (wire spacig) / 2, for sed overlapping with the boarder, overlaping fraction is multiplied
+      float h_e_sed; //!< deposited energy [MeV] from simEnergyDeposit (sed) in wire z +- (wire spacig) / 2, for sed overlapping with the boarder, overlaping fraction is multiplied
       float p_nelec; //!< Charge / number of electrons by particle
       float p_e; //!< Energy by particle [MeV]
       float x; //!< X-Position of deposition by particle [cm]

--- a/sbnanaobj/StandardRecord/SRTrueCaloPoint.h
+++ b/sbnanaobj/StandardRecord/SRTrueCaloPoint.h
@@ -16,8 +16,8 @@ namespace caf
 
       float h_nelec; //!< Charge / number of electrons by hit
       float h_e; //!< Energy by hit [MeV]
-      float h_nelec_sed; //!< number of electrons from simEnergyDeposit (sed) in wire z +- (wire spacig) / 2, for sed overlapping with the boarder, overlaping fraction is multiplied
-      float h_e_sed; //!< deposited energy [MeV] from simEnergyDeposit (sed) in wire z +- (wire spacig) / 2, for sed overlapping with the boarder, overlaping fraction is multiplied
+      float h_nelec_sed; //!< number of electrons from simEnergyDeposit (sed) in wire z +- (wire spacing) / 2, for sed overlapping with the border, overlaping fraction is multiplied
+      float h_e_sed; //!< deposited energy [MeV] from simEnergyDeposit (sed) in wire z +- (wire spacing) / 2, for sed overlapping with the border, overlaping fraction is multiplied
       float p_nelec; //!< Charge / number of electrons by particle
       float p_e; //!< Energy by particle [MeV]
       float x; //!< X-Position of deposition by particle [cm]

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -148,7 +148,8 @@
     <![CDATA[{ energy = onfile.energy; }]]>
   </ioread>
 
-  <class name="caf::SRTrueCaloPoint" ClassVersion="10">
+  <class name="caf::SRTrueCaloPoint" ClassVersion="11">
+   <version ClassVersion="11" checksum="3867618625"/>
    <version ClassVersion="10" checksum="4052698249"/>
   </class>
 


### PR DESCRIPTION
## Quick checklist

- [ V ] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [ ] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [ V ] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [ V ] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?

## Description

Adding h_nelec_sed and h_e_sed to SRTrueCaloPoint for better recombination studies.
These variables will save deposited energy and number of ionizing electrons collected from simEnergyDeposit within wire channel position +- spacing/2. They correspond to the true deposited energy and number of ionizing electrons in the hit pitch.
