### PR TITLE
Add more NuGraph2 variables to CAFs

### DIFF
--- a/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
@@ -4,8 +4,12 @@ namespace caf
 {
 
   SRNuGraphSliceInfo::SRNuGraphSliceInfo() : 
-    ng_vtx_hip_hits(INT_MIN),
+    mip_hits(INT_MIN),
+    hip_hits(INT_MIN),
     shr_hits(INT_MIN),
+    mhl_hits(INT_MIN),
+    dif_hits(INT_MIN),
+    ng_vtx_hip_hits(INT_MIN),
     unclustered_shr_hits(INT_MIN)
   {  }
 

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
@@ -4,7 +4,9 @@ namespace caf
 {
 
   SRNuGraphSliceInfo::SRNuGraphSliceInfo() : 
-    ng_vtx_hip_hits(INT_MIN)
+    ng_vtx_hip_hits(INT_MIN),
+    shr_hits(INT_MIN),
+    unclustered_shr_hits(INT_MIN)
   {  }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.cxx
@@ -1,1 +1,10 @@
 #include "sbnanaobj/StandardRecord/SRNuGraphScore.h"
+
+namespace caf
+{
+
+  SRNuGraphSliceInfo::SRNuGraphSliceInfo() : 
+    ng_vtx_hip_hits(INT_MIN)
+  {  }
+
+} // end namespace caf

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -21,7 +21,7 @@ namespace caf {
   public:
     SRNuGraphSliceInfo();
 
-    unsigned int ng_vtx_hip_hits;  ///< Number of hits tagged as HIP around the vertex (10 wires, 10 ticks)
+    int ng_vtx_hip_hits;  ///< Number of hits tagged as HIP around the vertex (10 wires, 10 ticks)
   };
 
   /**

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -19,12 +19,16 @@ namespace caf {
   */
   class SRNuGraphSliceInfo {
   public:
+  
     SRNuGraphSliceInfo();
 
-    int ng_vtx_hip_hits;      ///< Number of hits tagged as HIP around the vertex.
+    int mip_hits;             ///< Number of hits tagged as `MIP`.
+    int hip_hits;             ///< Number of hits tagged as `HIP`.
     int shr_hits;             ///< Number of hits tagged as `Shower`.
-    int unclustered_shr_hits; ///< Number of hits tagged as `Shower` not belonging to any PFP object.
-    
+    int mhl_hits;             ///< Number of hits tagged as `Michel`.
+    int dif_hits;             ///< Number of hits tagged as `Diffuse`.
+    int ng_vtx_hip_hits;      ///< Number of hits tagged as `HIP` around the reconstructed interaction vertex.
+    int unclustered_shr_hits; ///< Number of hits tagged as `Shower` not belonging to any reconstructed Pandora PFP object.
   };
 
   /**

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -21,7 +21,10 @@ namespace caf {
   public:
     SRNuGraphSliceInfo();
 
-    int ng_vtx_hip_hits;  ///< Number of hits tagged as HIP around the vertex (10 wires, 10 ticks)
+    int ng_vtx_hip_hits;      ///< Number of hits tagged as HIP around the vertex (10 wires, 40 ticks).
+    int shr_hits;             ///< Number of hits tagged as `Shower`.
+    int unclustered_shr_hits; ///< Number of hits tagged as `Shower` not belonging to any PFP object.
+    
   };
 
   /**

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -21,7 +21,7 @@ namespace caf {
   public:
     SRNuGraphSliceInfo();
 
-    int ng_vtx_hip_hits;      ///< Number of hits tagged as HIP around the vertex (10 wires, 40 ticks).
+    int ng_vtx_hip_hits;      ///< Number of hits tagged as HIP around the vertex.
     int shr_hits;             ///< Number of hits tagged as `Shower`.
     int unclustered_shr_hits; ///< Number of hits tagged as `Shower` not belonging to any PFP object.
     

--- a/sbnanaobj/StandardRecord/SRNuGraphScore.h
+++ b/sbnanaobj/StandardRecord/SRNuGraphScore.h
@@ -5,8 +5,24 @@
 #define SRNuGraphSCORE_H
 
 #include "sbnanaobj/StandardRecord/SRConstants.h"
+#include <climits>
 
 namespace caf {
+
+  /**
+  * @brief Information on the slice by NuGraph.
+  *
+  * This object summarizes the results from running NuGraph over hits in a slice
+  * (see e.g. [https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40585](SBN DocDB 40585).
+  *
+  * The number of HIP hits is computed for a circle around the vertex in each plane.
+  */
+  class SRNuGraphSliceInfo {
+  public:
+    SRNuGraphSliceInfo();
+
+    unsigned int ng_vtx_hip_hits;  ///< Number of hits tagged as HIP around the vertex (10 wires, 10 ticks)
+  };
 
   /**
   * @brief Categorization of the object/PFP by NuGraph.
@@ -37,6 +53,7 @@ namespace caf {
     float dif_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Diffuse`.
     float bkg_frac = caf::kSignalingNaN; ///< Fraction of hits that are labeled as `Background`.
   };
+  
 }
 
 #endif

--- a/sbnanaobj/StandardRecord/SRSlice.cxx
+++ b/sbnanaobj/StandardRecord/SRSlice.cxx
@@ -11,15 +11,11 @@ namespace caf
   SRSlice::SRSlice()
   {  }
 
-
   SRSlice::~SRSlice(){  }
-
 
   void SRSlice::setDefault()
   {
     charge         = -5;
   }
-
-
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -59,8 +59,8 @@ namespace caf
       float nu_score       { kSignalingNaN }; //!< Score of how neutrino-like the slice is according to pandora
       SRNuID nuid; //!< Neutrino ID Features (BDT inputs) going into nu_score calculation
 
-      float ng_filt_pass_frac { kSignalingNaN };  //!< Fraction of slice hits that pass the nugraph filter decoder
-      SRNuGraphSliceInfo ng_plane[3];  //!< Slice-level nugraph information, provided for each plane
+      float ng_filt_pass_frac { kSignalingNaN };  //!< Fraction of slice hits that pass the NuGraph2 filter decoder
+      SRNuGraphSliceInfo ng_plane[3];  //!< Slice-level NuGraph2 information, provided for each plane
 
       SRCRUMBSResult crumbs_result; //!< Score of how neutrino-like the slice is according to the CRUMBS ID
       

--- a/sbnanaobj/StandardRecord/SRSlice.h
+++ b/sbnanaobj/StandardRecord/SRSlice.h
@@ -18,6 +18,7 @@
 #include "sbnanaobj/StandardRecord/SRNuID.h"
 #include "sbnanaobj/StandardRecord/SRConstants.h"
 #include "sbnanaobj/StandardRecord/SRCVNScore.h"
+#include "sbnanaobj/StandardRecord/SRNuGraphScore.h"
 
 #include <climits>
 
@@ -56,11 +57,13 @@ namespace caf
       bool is_clear_cosmic { false };         //!< Whether pandora marks the slice as a "clear" cosmic
       int nu_pdg           { INT_MIN };       //!< PDG assigned to the PFParticle Neutrino
       float nu_score       { kSignalingNaN }; //!< Score of how neutrino-like the slice is according to pandora
-      float ng_filt_pass_frac { kSignalingNaN }; //!< Fraction of slice hits that pass the nugraph filter decoder
-      SRCRUMBSResult crumbs_result;  //!< Score of how neutrino-like the slice is according to the CRUMBS ID
-
       SRNuID nuid; //!< Neutrino ID Features (BDT inputs) going into nu_score calculation
 
+      float ng_filt_pass_frac { kSignalingNaN };  //!< Fraction of slice hits that pass the nugraph filter decoder
+      SRNuGraphSliceInfo ng_plane[3];  //!< Slice-level nugraph information, provided for each plane
+
+      SRCRUMBSResult crumbs_result; //!< Score of how neutrino-like the slice is according to the CRUMBS ID
+      
       std::vector<size_t> primary;             //!< ID's of primary tracks and showers in slice
       int                 self { INT_MIN };    //!< ID of the particle representing this slice
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -46,7 +46,8 @@
    <version ClassVersion="10" checksum="705810055"/>
   </class>
 
-  <class name="caf::SRNuGraphSliceInfo" ClassVersion="14" >
+  <class name="caf::SRNuGraphSliceInfo" ClassVersion="15" >
+   <version ClassVersion="15" checksum="2711257956"/>
    <version ClassVersion="14" checksum="809065913"/>
    <version ClassVersion="13" checksum="290910659"/>
    <version ClassVersion="12" checksum="434873519"/>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -46,7 +46,8 @@
    <version ClassVersion="10" checksum="705810055"/>
   </class>
 
-  <class name="caf::SRNuGraphSliceInfo" ClassVersion="13" >
+  <class name="caf::SRNuGraphSliceInfo" ClassVersion="14" >
+   <version ClassVersion="14" checksum="809065913"/>
    <version ClassVersion="13" checksum="290910659"/>
    <version ClassVersion="12" checksum="434873519"/>
   </class>

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -46,6 +46,11 @@
    <version ClassVersion="10" checksum="705810055"/>
   </class>
 
+  <class name="caf::SRNuGraphSliceInfo" ClassVersion="13" >
+   <version ClassVersion="13" checksum="290910659"/>
+   <version ClassVersion="12" checksum="434873519"/>
+  </class>
+
   <class name="caf::SRHit" ClassVersion="10">
    <version ClassVersion="10" checksum="1494967532"/>
   </class>
@@ -71,7 +76,11 @@
    <version ClassVersion="10" checksum="83320005"/>
   </class>
 
-  <class name="caf::SRSlice" ClassVersion="22">
+  <class name="caf::SRSlice" ClassVersion="26">
+   <version ClassVersion="26" checksum="2614728424"/>
+   <version ClassVersion="25" checksum="3061622568"/>
+   <version ClassVersion="24" checksum="2614728424"/>
+   <version ClassVersion="23" checksum="3732772050"/>
    <version ClassVersion="22" checksum="2124497341"/>
    <version ClassVersion="21" checksum="3825441135"/>
    <version ClassVersion="20" checksum="1917004696"/>


### PR DESCRIPTION
This PR adds some plane-by-plane slice-level variables to the CAFs, based on the predictions from NuGraph2.
Specifically:

- the number of hits tagged by NuGraph2 for each category in the slice (e.g., `shr_hits` for the `Shower` category);
- `ng_vtx_hip_hits`: the number of "HIP" hits tagged by NuGraph2 near the reconstructed interaction vertex. Wire and tick allowed distances are configurable. Standard is 10 wires and 50 ticks;
- `unclustered_shr_hits`: the number of hits tagged as "shower" by NuGraph2 in the slice, that are not associated to any reconstructed PFP.

___
### Associated PRs

- https://github.com/SBNSoftware/sbncode/pull/616

___
### Checklist

- [ ] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against? Will do, after review.
- [x] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [x] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [x] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?
