### PR TITLE
Extra SBND CRT Branches

### DIFF
--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
@@ -3,6 +3,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "sbnanaobj/StandardRecord/SRCRTSpacePoint.h"
+#include "sbnanaobj/StandardRecord/SRConstants.h"
 
 #include <climits>
 

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
@@ -13,8 +13,8 @@ namespace caf
     time(std::numeric_limits<float>::signaling_NaN()),
     time_err(std::numeric_limits<float>::signaling_NaN()),
     complete(false),
-    nhits(std::numeric_limits<int>::lowest()),
-    tagger(std::numeric_limits<int>::lowest())
+    nhits(caf::kUninitializedInt),
+    tagger(caf::kUninitializedInt)
   {}
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
@@ -13,9 +13,9 @@ namespace caf
     pe(std::numeric_limits<float>::signaling_NaN()),
     time(std::numeric_limits<float>::signaling_NaN()),
     time_err(std::numeric_limits<float>::signaling_NaN()),
-    complete(false),
     nhits(caf::kUninitializedInt),
-    tagger(caf::kUninitializedInt)
+    tagger(caf::kUninitializedInt),
+    complete(false)
   {}
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.cxx
@@ -12,7 +12,9 @@ namespace caf
     pe(std::numeric_limits<float>::signaling_NaN()),
     time(std::numeric_limits<float>::signaling_NaN()),
     time_err(std::numeric_limits<float>::signaling_NaN()),
-    complete(false)
+    complete(false),
+    nhits(std::numeric_limits<int>::lowest()),
+    tagger(std::numeric_limits<int>::lowest())
   {}
 } // end namespace caf
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
@@ -19,9 +19,9 @@ namespace caf
       float      pe;           // total PE
       float      time;         // time [ns]
       float      time_err;     // time_err [ns]
-      bool       complete;     // was cluster made from perpendicular & overlapping strips?
       int        nhits;        // the number of strip hits contributing to the space point
       int        tagger;       // the tagger the space point is on
+      bool       complete;     // was cluster made from perpendicular & overlapping strips?
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
@@ -12,7 +12,6 @@ namespace caf
     {
     public:
       SRCRTSpacePoint();
-      virtual ~SRCRTSpacePoint() {}
       
       SRVector3D position;     ///< position [cm]
       SRVector3D position_err; ///< positional spread [cm]

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
@@ -14,14 +14,14 @@ namespace caf
       SRCRTSpacePoint();
       virtual ~SRCRTSpacePoint() {}
       
-      SRVector3D position;     // position [cm]
-      SRVector3D position_err; // positional spread [cm]
-      float      pe;           // total PE
-      float      time;         // time [ns]
-      float      time_err;     // time_err [ns]
-      int        nhits;        // the number of strip hits contributing to the space point
-      int        tagger;       // the tagger the space point is on
-      bool       complete;     // was cluster made from perpendicular & overlapping strips?
+      SRVector3D position;     ///< position [cm]
+      SRVector3D position_err; ///< positional spread [cm]
+      float      pe;           ///< total PE
+      float      time;         ///< time [ns]
+      float      time_err;     ///< time_err [ns]
+      int        nhits;        ///< the number of strip hits contributing to the space point
+      int        tagger;       ///< the tagger the space point is on
+      bool       complete;     ///< was cluster made from perpendicular & overlapping strips?
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePoint.h
@@ -20,6 +20,8 @@ namespace caf
       float      time;         // time [ns]
       float      time_err;     // time_err [ns]
       bool       complete;     // was cluster made from perpendicular & overlapping strips?
+      int        nhits;        // the number of strip hits contributing to the space point
+      int        tagger;       // the tagger the space point is on
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.cxx
@@ -7,6 +7,7 @@
 namespace caf
 {
   SRCRTSpacePointMatch::SRCRTSpacePointMatch():
+    matched(false),
     score(std::numeric_limits<float>::signaling_NaN())
   {}
 }

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.cxx
@@ -7,8 +7,8 @@
 namespace caf
 {
   SRCRTSpacePointMatch::SRCRTSpacePointMatch():
-    matched(false),
-    score(std::numeric_limits<float>::signaling_NaN())
+    score(std::numeric_limits<float>::signaling_NaN()),
+    matched(false)
   {}
 }
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
@@ -14,6 +14,7 @@ namespace caf
       SRCRTSpacePointMatch();
       virtual ~SRCRTSpacePointMatch() {}
 
+      bool            matched;    // whether or not a match was made
       SRCRTSpacePoint spacepoint; // the spacepoint
       float           score;      // assessment of quality of matching (depends on alg configuration)
     };

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
@@ -13,9 +13,9 @@ namespace caf
     public:
       SRCRTSpacePointMatch();
 
-      bool            matched;    ///< whether or not a match was made
       SRCRTSpacePoint spacepoint; ///< the spacepoint
       float           score;      ///< assessment of quality of matching (depends on alg configuration)
+      bool            matched;    ///< whether or not a match was made
     };
 }
 

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
@@ -12,7 +12,6 @@ namespace caf
     {
     public:
       SRCRTSpacePointMatch();
-      virtual ~SRCRTSpacePointMatch() {}
 
       bool            matched;    // whether or not a match was made
       SRCRTSpacePoint spacepoint; // the spacepoint

--- a/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTSpacePointMatch.h
@@ -13,9 +13,9 @@ namespace caf
     public:
       SRCRTSpacePointMatch();
 
-      bool            matched;    // whether or not a match was made
-      SRCRTSpacePoint spacepoint; // the spacepoint
-      float           score;      // assessment of quality of matching (depends on alg configuration)
+      bool            matched;    ///< whether or not a match was made
+      SRCRTSpacePoint spacepoint; ///< the spacepoint
+      float           score;      ///< assessment of quality of matching (depends on alg configuration)
     };
 }
 

--- a/sbnanaobj/StandardRecord/SRCRTTrackMatch.h
+++ b/sbnanaobj/StandardRecord/SRCRTTrackMatch.h
@@ -12,7 +12,7 @@ namespace caf
     public:
 
       SRCRTTrackMatch();
-      virtual ~SRCRTTrackMatch() {}
+
       float time;  ///< Time of the CRT Track [us]
       float angle; ///< Relative angle between the TPC track and CRT track [rad]
     };

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
@@ -22,9 +22,7 @@ namespace caf
       float                     time_err; // error in average time [ns]
       float                     pe;       // total PE;
       float                     tof;      // time from first space point to last [ns]
-
-      // TODO: Find way of adding taggers field
-      //      std::set<SBNDCRTTagger_t> taggers;  // which taggers were used to create the track
+      std::vector<int>          taggers;  // the taggers that were used to create the track
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
@@ -17,12 +17,12 @@ namespace caf
       SRSBNDCRTTrack();
       virtual ~SRSBNDCRTTrack() {}
       
-      std::vector<SRVector3D>   points;   // fitted track points at each tagger [cm]
-      float                     time;     // average time [ns]
-      float                     time_err; // error in average time [ns]
-      float                     pe;       // total PE;
-      float                     tof;      // time from first space point to last [ns]
-      std::vector<int>          taggers;  // the taggers that were used to create the track
+      std::vector<SRVector3D>   points;   ///< fitted track points at each tagger [cm]
+      float                     time;     ///< average time [ns]
+      float                     time_err; ///< error in average time [ns]
+      float                     pe;       ///< total PE;
+      float                     tof;      ///< time from first space point to last [ns]
+      std::vector<int>          taggers;  ///< the taggers that were used to create the track (see docDB #46042, section 2)
     };
 } // end namespace
 

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrack.h
@@ -15,7 +15,6 @@ namespace caf
     {
     public:
       SRSBNDCRTTrack();
-      virtual ~SRSBNDCRTTrack() {}
       
       std::vector<SRVector3D>   points;   ///< fitted track points at each tagger [cm]
       float                     time;     ///< average time [ns]

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.cxx
@@ -7,8 +7,8 @@
 namespace caf
 {
   SRSBNDCRTTrackMatch::SRSBNDCRTTrackMatch():
-    matched(false),
-    score(std::numeric_limits<float>::signaling_NaN())
+    score(std::numeric_limits<float>::signaling_NaN()),
+    matched(false)
   {}
 }
 ////////////////////////////////////////////////////////////////////////

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.cxx
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.cxx
@@ -7,6 +7,7 @@
 namespace caf
 {
   SRSBNDCRTTrackMatch::SRSBNDCRTTrackMatch():
+    matched(false),
     score(std::numeric_limits<float>::signaling_NaN())
   {}
 }

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
@@ -14,8 +14,9 @@ namespace caf
       SRSBNDCRTTrackMatch();
       virtual ~SRSBNDCRTTrackMatch() {}
       
-      SRSBNDCRTTrack track; // the track
-      float          score; // assessment of quality of matching (depends on alg configuration)
+      bool           matched; // whether or not a match was made
+      SRSBNDCRTTrack track;   // the track
+      float          score;   // assessment of quality of matching (depends on alg configuration)
     };
 }
 

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
@@ -14,9 +14,9 @@ namespace caf
       SRSBNDCRTTrackMatch();
       virtual ~SRSBNDCRTTrackMatch() {}
       
-      bool           matched; ///< whether or not a match was made
       SRSBNDCRTTrack track;   ///< the track
       float          score;   ///< assessment of quality of matching (depends on alg configuration)
+      bool           matched; ///< whether or not a match was made
     };
 }
 

--- a/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
+++ b/sbnanaobj/StandardRecord/SRSBNDCRTTrackMatch.h
@@ -14,9 +14,9 @@ namespace caf
       SRSBNDCRTTrackMatch();
       virtual ~SRSBNDCRTTrackMatch() {}
       
-      bool           matched; // whether or not a match was made
-      SRSBNDCRTTrack track;   // the track
-      float          score;   // assessment of quality of matching (depends on alg configuration)
+      bool           matched; ///< whether or not a match was made
+      SRSBNDCRTTrack track;   ///< the track
+      float          score;   ///< assessment of quality of matching (depends on alg configuration)
     };
 }
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -421,7 +421,8 @@
    <version ClassVersion="10" checksum="3912601582"/>
   </class>
 
-  <class name="caf::SRCRTSpacePointMatch" ClassVersion="10">
+  <class name="caf::SRCRTSpacePointMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="414814289"/>
    <version ClassVersion="10" checksum="382456729"/>
   </class>
 
@@ -430,7 +431,8 @@
    <version ClassVersion="10" checksum="1967800431"/>
   </class>
 
-  <class name="caf::SRSBNDCRTTrackMatch" ClassVersion="10">
+  <class name="caf::SRSBNDCRTTrackMatch" ClassVersion="11">
+   <version ClassVersion="11" checksum="3360963232"/>
    <version ClassVersion="10" checksum="2486605052"/>
   </class>
   

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -416,7 +416,8 @@
   </class>
   <class name="std::vector<caf::SRTPCPMTBarycenterMatch>"/>
 
-  <class name="caf::SRCRTSpacePoint" ClassVersion="10">
+  <class name="caf::SRCRTSpacePoint" ClassVersion="11">
+   <version ClassVersion="11" checksum="2928297658"/>
    <version ClassVersion="10" checksum="3912601582"/>
   </class>
 
@@ -424,7 +425,8 @@
    <version ClassVersion="10" checksum="382456729"/>
   </class>
 
-  <class name="caf::SRSBNDCRTTrack" ClassVersion="10">
+  <class name="caf::SRSBNDCRTTrack" ClassVersion="11">
+   <version ClassVersion="11" checksum="1038334522"/>
    <version ClassVersion="10" checksum="1967800431"/>
   </class>
 

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -417,12 +417,12 @@
   <class name="std::vector<caf::SRTPCPMTBarycenterMatch>"/>
 
   <class name="caf::SRCRTSpacePoint" ClassVersion="11">
-   <version ClassVersion="11" checksum="2928297658"/>
+   <version ClassVersion="11" checksum="1494823436"/>
    <version ClassVersion="10" checksum="3912601582"/>
   </class>
 
   <class name="caf::SRCRTSpacePointMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="414814289"/>
+   <version ClassVersion="11" checksum="2257480785"/>
    <version ClassVersion="10" checksum="382456729"/>
   </class>
 
@@ -432,7 +432,7 @@
   </class>
 
   <class name="caf::SRSBNDCRTTrackMatch" ClassVersion="11">
-   <version ClassVersion="11" checksum="3360963232"/>
+   <version ClassVersion="11" checksum="2788704610"/>
    <version ClassVersion="10" checksum="2486605052"/>
   </class>
   


### PR DESCRIPTION
## Quick checklist

- [x] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [ ] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [x] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [x] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?

## Description

I am starting to put together slides and PRs to preserve work of mine that lives offline before I leave.

The SBND CRT information in the CAFs is missing a few little pieces that are useful to analyzers (and simple to add as they are already present in the reconstruction objects).
- The tagger variable (which wall) for the CRTSpacePoints
- The number of contributing hits variable for the CRTSpacePoints
- The vector of taggers variable (which walls) for the CRTTrack
- Boolean fields to quickly establish whether or not a CRT-TPC match is present.

This PR adds those branches to the StandardRecord structure.

Accompanying PR: https://github.com/SBNSoftware/sbncode/pull/632
It is documented in slides: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=45715