### PR TITLE
SBND Timing Reconstruction Refactor

### DIFF
--- a/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
@@ -20,18 +20,31 @@ namespace caf
    * Each shift is in [ns]
    *
    * For more information, see
-   * [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090).
+   * legacy: [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090).
+   * new: ???
    */
 
-  struct SRSBNDFrameShiftInfo {
-    static constexpr uint16_t NoType = std::numeric_limits<uint16_t>::max();
-    uint16_t timingType = NoType; ///< Types of decoded frames: 0 - SPEC TDC ETRIG, 1 - HLT ETRIG, 2 - Do Nothing
-    double frameTdcCrtt1 = kSignalingNaN; ///< Shift from decoded frame to SPEC-TDC CRT T1 [ns]
-    double frameTdcBes = kSignalingNaN; ///< Shift from decoded frame to SPEC-TDC BES [ns]
-    double frameTdcRwm = kSignalingNaN; ///< Shift from decoded frame to SPEC-TDC RWM [ns]
-    double frameHltCrtt1 = kSignalingNaN; ///< Shift from decoded frame to HLT CRT T1 [ns]
-    double frameHltBeamGate = kSignalingNaN; ///< Shift from decoded frame to HLT Beam Gate [ns]
-    double frameApplyAtCaf = kSignalingNaN; ///< Frame to shift to when running at CAF stage
+  struct SRSBNDFrameShiftInfo { 
+    
+    static constexpr uint16_t InvalidType = std::numeric_limits<uint16_t>::max();
+    static constexpr uint16_t InvalidChannel = std::numeric_limits<uint16_t>::max();
+    static constexpr uint64_t InvalidTimestamp = std::numeric_limits<uint64_t>::max();
+
+    uint64_t frameCrtt1         = InvalidTimestamp; ///< Frame for CRT T1 signal [ns]
+    uint16_t timingTypeCrtt1    = InvalidType; ///< Types of CRT T1 frame
+    uint16_t timingChannelCrtt1 = InvalidChannel; ///< Channel of CRT T1 frame
+
+    uint64_t frameBeamGate         = InvalidTimestamp; ///< Frame for Beam Gate [ns]
+    uint16_t timingTypeBeamGate    = InvalidType; ///< Types of Beam Gate frame
+    uint16_t timingChannelBeamGate = InvalidChannel; ///< Channel of Beam Gate frame
+
+    uint64_t frameEtrig         = InvalidTimestamp; ///< Frame for ETRIG [ns]
+    uint16_t timingTypeEtrig    = InvalidType; ///< Types of ETRIG frame
+    uint16_t timingChannelEtrig = InvalidChannel; ///< Channel of ETRIG frame
+
+    uint64_t frameDefault         = InvalidTimestamp; ///< Default frame depending on the stream type [ns]
+    uint16_t timingTypeDefault    = InvalidType; ///< Types of default frame
+    uint16_t timingChannelDefault = InvalidChannel; ///< Channel of default frame
   };
 } // end namespace
 #endif // SRSBNDFRAMESHIFTINFO_H

--- a/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
@@ -1,8 +1,7 @@
 /**
  * @file   /sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
- * @brief  Defines CAF data structures to store sbnd::timing::FrameShiftInfo (docdb#43090).
+ * @brief  Defines CAF data structures to store sbnd::timing::FrameShiftInfo 
  * @author Vu Chi Lan Nguyen
- * @date   August 29, 2025
  *
  */
 

--- a/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDFrameShiftInfo.h
@@ -20,8 +20,8 @@ namespace caf
    * Each shift is in [ns]
    *
    * For more information, see
-   * legacy: [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090).
-   * new: ???
+   * legacy: [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090)
+   * new: [SBN DocDB 46654](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=46654)
    */
 
   struct SRSBNDFrameShiftInfo { 

--- a/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
@@ -24,16 +24,16 @@ namespace caf
 
   struct SRSBNDTimingInfo
     {
-      static constexpr uint64_t NoTimestamp = std::numeric_limits<uint32_t>::max();
-      
-      uint64_t rawDAQHeaderTimestamp = NoTimestamp; ///< Timestamp when the event is built by the event builder at DAQ-level
-      uint64_t tdcCrtt1 = NoTimestamp; ///< Timestamp of BNB stream CRT T1 Reset recorded by the SPEC-TDC
-      uint64_t tdcBes = NoTimestamp; ///< Timestamp of BES signal sent by MFTU recorded by the SPEC-TDC
-      uint64_t tdcRwm = NoTimestamp; ///< Timestamp of RWM signal recorded by the SPEC-TDC
-      uint64_t tdcEtrig = NoTimestamp; ///< Timestamp of Event Trigger (ETRIG) sent by the PTB recorded by the SPEC-TDC 
-      uint64_t hltCrtt1 = NoTimestamp; ///< Timestamp of BNB and Offbeam stream CRT T1 Reset High Level Trigger (HLT) created by the PTB
-      uint64_t hltEtrig = NoTimestamp; ///< Timestamp of ETRIG HLT created by the PTB
-      uint64_t hltBeamGate = NoTimestamp; ///< Timestamp of Beam Gate Acceptance HLT created by the PTB
+      static constexpr uint64_t InvalidTimestamp = std::numeric_limits<uint64_t>::max();
+
+      uint64_t rawDAQHeaderTimestamp = InvalidTimestamp; ///< Timestamp when the event is built by the event builder at DAQ-level
+      uint64_t tdcCrtt1 = InvalidTimestamp; ///< Timestamp of BNB stream CRT T1 Reset recorded by the SPEC-TDC
+      uint64_t tdcBes = InvalidTimestamp; ///< Timestamp of BES signal sent by MFTU recorded by the SPEC-TDC
+      uint64_t tdcRwm = InvalidTimestamp; ///< Timestamp of RWM signal recorded by the SPEC-TDC
+      uint64_t tdcEtrig = InvalidTimestamp; ///< Timestamp of Event Trigger (ETRIG) sent by the PTB recorded by the SPEC-TDC 
+      uint64_t hltCrtt1 = InvalidTimestamp; ///< Timestamp of BNB and Offbeam stream CRT T1 Reset High Level Trigger (HLT) created by the PTB
+      uint64_t hltEtrig = InvalidTimestamp; ///< Timestamp of ETRIG HLT created by the PTB
+      uint64_t hltBeamGate = InvalidTimestamp; ///< Timestamp of Beam Gate Acceptance HLT created by the PTB
     };
 } // end namespace
 #endif // SRSBNDTIMINGINFO_H

--- a/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
@@ -19,7 +19,8 @@ namespace caf
    * Each timestamp is in UNIX Timestamp Format [ns]
    *
    * For more information, see
-   * [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090).
+   * legacy: [SBN DocDB 43090](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43090)
+   * new: [SBN DocDB 46654](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=46654)
    */
 
   struct SRSBNDTimingInfo

--- a/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
+++ b/sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
@@ -1,8 +1,7 @@
 /**
  * @file   /sbnanaobj/StandardRecord/SRSBNDTimingInfo.h
- * @brief  Defines CAF data structures to store sbnd::timing::TimingInfo (docdb#43090).
+ * @brief  Defines CAF data structures to store sbnd::timing::TimingInfo
  * @author Vu Chi Lan Nguyen
- * @date   August 29, 2025
  *
  */
     

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -422,7 +422,8 @@
   <class name="std::vector<caf::SRCRTSpacePoint>" />
   <class name="std::vector<caf::SRSBNDCRTTrack>" />
 
-  <class name="caf::SRSBNDFrameShiftInfo" ClassVersion="10">
+  <class name="caf::SRSBNDFrameShiftInfo" ClassVersion="11">
+   <version ClassVersion="11" checksum="2340993735"/>
    <version ClassVersion="10" checksum="2564414428"/>
   </class>
   <class name="caf::SRSBNDTimingInfo" ClassVersion="10">


### PR DESCRIPTION
## Description 

- Timing reconstruction is refactored in this PR, affecting the decode/reconstruction workflow of CRT/PMT/XA.
- After the refactoring, the @FrameShiftModule@ runs first in the decode chain, outputs timing products to be used at PMT/XA decoder and CRTStrip reconstruction.
- Relevant PMT reconstruction modules at Reco1/Reco2 are updated.
- The timing correction applied at CAFMakeer is undone. This should ressolve this issue: https://github.com/SBNSoftware/sbncode/issues/567
- Details and validation plots can before in the linked docdb.

### Link(s) to docdb describing changes (optional)

https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=45982

### Relevant PR links (optional)

This PR needs the XA decoder PR in sbndcode to go in first:
https://github.com/SBNSoftware/sbndcode/pull/847 

This PR needs to be merged together with this group of PRs:
- sbndcode: https://github.com/SBNSoftware/sbndcode/pull/915
- sbncode: https://github.com/SBNSoftware/sbncode/pull/637
- sbnobj: https://github.com/SBNSoftware/sbnobj/pull/170
- sbnanaobj:https://github.com/SBNSoftware/sbnanaobj/pull/188

## Quick checklist

- [ ] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [ ] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [ ] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [x] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?
