### PR TITLE
Added new blip energy records

### DIFF
--- a/sbnanaobj/StandardRecord/SRBlip.h
+++ b/sbnanaobj/StandardRecord/SRBlip.h
@@ -39,6 +39,9 @@ namespace caf
       float     energy=caf::kSignalingNaN;          ///< Reconstructed energy in the calorimetry plane (const dE/dx, fcl-configurable) [GeV]
       float     energyESTAR=caf::kSignalingNaN;     ///< Reconstructed energy in the calorimetry plane (ESTAR method from ArgoNeuT)    [GeV]
       float     energyPSTAR=caf::kSignalingNaN;     ///< Reconstructed energy in the calorimetry plane (PSTAR method similar with ESTAR method from ArgoNeuT) [GeV]
+      float     energyNoDriftCorr=caf::kSignalingNaN;          ///< Reconstructed energy in the calorimetry plane (const dE/dx, fcl-configurable) [GeV]
+      float     energyESTARnoDriftCorr=caf::kSignalingNaN;     ///< Reconstructed energy in the calorimetry plane (ESTAR method from ArgoNeuT)    [GeV]
+      float     energyPSTARnoDriftCorr=caf::kSignalingNaN;     ///< Reconstructed energy in the calorimetry plane (PSTAR method similar with ESTAR method from ArgoNeuT) [GeV]
       float     proxTrkDist=caf::kSignalingNaN;     ///< 3-D distance to closest track, assuming the blip was coincident with event trigger [cm]
       /*!
         for properly flash matched out-of-time tracks this distance will be wrong! The blips have no such flash matching ability as of yet

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -341,7 +341,8 @@
    <version ClassVersion="10" checksum="4159815756"/>
   </class>
 
-  <class name="caf::SRBlip" ClassVersion="10">
+  <class name="caf::SRBlip" ClassVersion="11">
+   <version ClassVersion="11" checksum="2976132797"/>
    <version ClassVersion="10" checksum="238037982"/>
   </class>
 


### PR DESCRIPTION
Adding additional blip energy variables so analyzers have access to a drift corrected energy, as well as an explicitly not drift corrected one.

All drift corrections are anchored to the event timestamp, so the beam blips will come out with the right energy. Any out-of-time blip activity will be mis-corrected, so the noDriftCorrection variables are saved as new variables.