### PR TITLE
[spack mpd] use PROJECT_BINARY_DIR which points to build directory for last declared project

### DIFF
--- a/sbnanaobj/StandardRecord/Flat/CMakeLists.txt
+++ b/sbnanaobj/StandardRecord/Flat/CMakeLists.txt
@@ -20,5 +20,5 @@ target_include_directories(sbnanaobj_StandardRecordFlat PRIVATE ${_srproxy_bin_d
 if (DEFINED ENV{MRB_BUILDDIR})
   install_headers(EXTRAS $ENV{MRB_BUILDDIR}/sbnanaobj/sbnanaobj/StandardRecord/Flat/FlatRecord.h $ENV{MRB_BUILDDIR}/sbnanaobj/sbnanaobj/StandardRecord/Flat/FwdDeclare.h)
 else()
-  install_headers(EXTRAS ${CMAKE_BINARY_DIR}/sbnanaobj/StandardRecord/Flat/FlatRecord.h ${CMAKE_BINARY_DIR}/sbnanaobj/StandardRecord/Flat/FwdDeclare.h)
+  install_headers(EXTRAS ${PROJECT_BINARY_DIR}/sbnanaobj/StandardRecord/Flat/FlatRecord.h ${PROJECT_BINARY_DIR}/sbnanaobj/StandardRecord/Flat/FwdDeclare.h)
 endif()

--- a/sbnanaobj/StandardRecord/Proxy/CMakeLists.txt
+++ b/sbnanaobj/StandardRecord/Proxy/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(sbnanaobj_StandardRecordProxy PRIVATE ${_srproxy_bin_
 if (DEFINED ENV{MRB_BUILDDIR})
   install_headers(EXTRAS $ENV{MRB_BUILDDIR}/sbnanaobj/sbnanaobj/StandardRecord/Proxy/SRProxy.h $ENV{MRB_BUILDDIR}/sbnanaobj/sbnanaobj/StandardRecord/Proxy/FwdDeclare.h)
 else()
-  install_headers(EXTRAS ${CMAKE_BINARY_DIR}/sbnanaobj/StandardRecord/Proxy/SRProxy.h ${CMAKE_BINARY_DIR}/sbnanaobj/StandardRecord/Proxy/FwdDeclare.h)
+  install_headers(EXTRAS ${PROJECT_BINARY_DIR}/sbnanaobj/StandardRecord/Proxy/SRProxy.h ${PROJECT_BINARY_DIR}/sbnanaobj/StandardRecord/Proxy/FwdDeclare.h)
 endif()


### PR DESCRIPTION
Adjust where CMake looks for generated header so it works with spack mpd or spack build
