### PR TITLE
Add new correctedopflash info to SR object

### DIFF
--- a/sbnanaobj/StandardRecord/SRCorrectedOpFlash.cxx
+++ b/sbnanaobj/StandardRecord/SRCorrectedOpFlash.cxx
@@ -17,6 +17,8 @@ namespace caf
     NuToFLight            =                             -9999.;
     NuToFCharge           =                             -9999.;
     OpFlashT0Corrected    =                             -9999.;
+    ParticlePropagationTime =                             -9999.;
+    PhotonPropagationTime   =                             -9999.;
   }
 
 } // end namespace caf

--- a/sbnanaobj/StandardRecord/SRCorrectedOpFlash.h
+++ b/sbnanaobj/StandardRecord/SRCorrectedOpFlash.h
@@ -21,6 +21,8 @@ namespace caf
     float        NuToFLight             {  -9999.  };      ///< | Nu ToF using light only | (us)
     float        NuToFCharge             {  -9999.  };       ///< | Nu ToF Z from tpc vertex | (us)
     float        OpFlashT0Corrected    {  -9999.  };       ///< | OpFlash Time wrt RWM time after light propagation corrections | (us)
+    float        ParticlePropagationTime {  -9999.  };       ///< | Average particle propagation time from vertex to emission point | (us)
+    float        PhotonPropagationTime   {  -9999.  };       ///< | Average photon propagation time from emission point to PMT| (us)
     /// @}
 
     void setDefault();

--- a/sbnanaobj/StandardRecord/classes_def.xml
+++ b/sbnanaobj/StandardRecord/classes_def.xml
@@ -414,7 +414,8 @@
    <version ClassVersion="10" checksum="2672302824"/>
   </class>
 
-  <class name="caf::SRCorrectedOpFlash" ClassVersion="14">
+  <class name="caf::SRCorrectedOpFlash" ClassVersion="15">
+   <version ClassVersion="15" checksum="2699494482"/>
    <version ClassVersion="14" checksum="2247699110"/>
    <version ClassVersion="13" checksum="3257300089"/>
    <version ClassVersion="12" checksum="1558889595"/>


### PR DESCRIPTION
## Quick checklist

- [x] Have you run `git fetch` and pulled the latest changes from the branch you're basing your PR against?
- [x] If you're adding new classes, have you added them to classes_def.xml in the relevant directory?
- [x] Have you added a checksum in classes_def.xml to **any and all** new classes you're implementing, *and rebuilt*?
- [x] If you're updating classes, have you incremented the `ClassVersion` **by one** compared to develop in classes_def.xml?

## Description

Please provide a short description of your PR.
This PR modifies the SRCorrectedOpFlashTiming object to include the photon time of flight and particle propagation time used during the correction of the op flash timing. These attributes are required for downstream correction. More information can be found [here](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=47101). 

This PR should be merged with 
https://github.com/SBNSoftware/sbndcode/pull/946
https://github.com/SBNSoftware/sbnobj/pull/175
https://github.com/SBNSoftware/sbncode/pull/666